### PR TITLE
Make tf scripts installed by catkin rosrun-able

### DIFF
--- a/tf/CMakeLists.txt
+++ b/tf/CMakeLists.txt
@@ -140,6 +140,13 @@ install(TARGETS ${PROJECT_NAME} tf_echo tf_empty_listener tf_change_notifier tf_
 install(TARGETS pytf_py
   LIBRARY DESTINATION ${CMAKE_INSTALL_PREFIX}/${PYTHON_INSTALL_DIR}/tf)
 
+# Install rosrun-able scripts
+install(PROGRAMS 
+  scripts/bullet_migration_sed.py
+  scripts/tf_remap
+  scripts/view_frames
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION} )
+
 # Need to install python msg and srv directories manually because genmsg
 # specifically avoids installing python message code if catkin_python_setup()
 # has been used.  See https://github.com/ros/genmsg/issues/10

--- a/tf/setup.py
+++ b/tf/setup.py
@@ -6,9 +6,6 @@ from catkin_pkg.python_setup import generate_distutils_setup
 d = generate_distutils_setup(
     packages=['tf'],
     package_dir={'': 'src'},
-    scripts=['scripts/bullet_migration_sed.py',
-             'scripts/tf_remap',
-             'scripts/view_frames'],
     requires=['genmsg', 'genpy', 'roslib', 'rospkg', 'geometry_msgs', 'sensor_msgs', 'std_msgs']
 )
 


### PR DESCRIPTION
In the groovy catkin migration, the tf scripts like tf_remap and view_frames were put into the setup.py file as "scripts" but this installs them to the /bin directory instead of the tf libexec directory. 
