### PR TITLE
fixes bug in getAngleShortestPath

### DIFF
--- a/tf/CMakeLists.txt
+++ b/tf/CMakeLists.txt
@@ -77,6 +77,7 @@ add_rostest(test/test_message_filter.xml)
 #target_link_libraries(tf_benchmark ${PROJECT_NAME})
 
 add_executable(btTest test/quaternion.cpp)
+add_executable(quaternionAxisAngleTest test/quaternion_axis_angle.cpp)
 
 catkin_add_gtest(testListener test/testListener.cpp)
 target_link_libraries(testListener ${PROJECT_NAME})

--- a/tf/include/tf/LinearMath/Quaternion.h
+++ b/tf/include/tf/LinearMath/Quaternion.h
@@ -154,7 +154,7 @@ public:
    * @param q The other quaternion */
 	tfScalar dot(const Quaternion& q) const
 	{
-		return m_floats[0] * q.x() + m_floats[1] * q.y() + m_floats[2] * q.z() + m_floats[3] * q.m_floats[3];
+		return m_floats[0] * q.x() + m_floats[1] * q.y() + m_floats[2] * q.z() + m_floats[3] * q.w();
 	}
 
   /**@brief Return the length squared of the quaternion */
@@ -235,13 +235,10 @@ public:
 	/**@brief Return the angle of rotation represented by this quaternion along the shortest path*/
 	tfScalar getAngleShortestPath() const 
 	{
-	tfScalar s;
-		if (dot(*this) < 0)
-			s = tfScalar(2.) * tfAcos(m_floats[3]);
+		if (dot(getIdentity()) < 0)
+			return tfAcos(-m_floats[3]) * tfScalar(2.0);
 		else
-			s = tfScalar(2.) * tfAcos(-m_floats[3]);
-
-		return s;
+			return tfAcos( m_floats[3]) * tfScalar(2.0);
 	}
 
 	/**@brief Return the axis of the rotation represented by this quaternion */

--- a/tf/test/quaternion_axis_angle.cpp
+++ b/tf/test/quaternion_axis_angle.cpp
@@ -78,7 +78,7 @@ int main(int argc, char **argv){
       tfScalar angle_out = 2*q_rotated.angle(q_identity); // why the HECK is this the half angle?
       tfScalar angle_shortest = q_rotated.angleShortestPath(q_identity);
       //std::printf("angle(identity), angleShortestPath(identity):\n");
-      std::printf("               angle(identity): %.3f @ [%.3f, %.3f, %.3f] \n",
+      std::printf("             2*angle(identity): %.3f @ [%.3f, %.3f, %.3f] \n",
                   angle_out, axis_out.x(), axis_out.y(), axis_out.z());
       std::printf("   angleShortestPath(identity): %.3f\n",
                   angle_shortest);

--- a/tf/test/quaternion_axis_angle.cpp
+++ b/tf/test/quaternion_axis_angle.cpp
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2008, Willow Garage, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Willow Garage, Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <vector>
+#include <sys/time.h>
+#include <cstdio>
+
+#include "tf/LinearMath/Transform.h"
+
+
+void seed_rand()
+{
+  //Seed random number generator with current microseond count
+  timeval temp_time_struct;
+  gettimeofday(&temp_time_struct,NULL);
+  srand(temp_time_struct.tv_usec);
+};
+
+
+int main(int argc, char **argv){
+
+  unsigned int runs = 400;
+  seed_rand();
+
+  std::vector<tf::Vector3> axes;
+  axes.push_back(tf::Vector3(1,0,0));
+  axes.push_back(tf::Vector3(0,1,0));
+  axes.push_back(tf::Vector3(0,0,1));
+
+  tf::Quaternion q_identity(0,0,0,1);
+  tf::Quaternion q_rotated(0,0,0,1);
+
+  for(unsigned int a = 0; a < axes.size(); a++)
+  {
+    const tf::Vector3& axis = axes[a];
+
+    for ( unsigned int i = 0; i < 360 ; i+=60 )
+    {
+      double angle = i*M_PI/180;
+      q_rotated.setRotation(axis, angle);
+
+      // Compute rotation axis from quaternion
+      tf::Vector3 axis_out = q_rotated.getAxis();
+
+      // Print the input values
+      std::printf("- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -\n");
+      std::printf("                         input: %.3f @ [%.3f, %.3f, %.3f]\n",
+                  angle,
+                  axis.x(), axis.y(), axis.z());
+
+      // Compute and print the axis/angle of this quaternion explicitly from identity.
+      tfScalar angle_out = 2*q_rotated.angle(q_identity); // why the HECK is this the half angle?
+      tfScalar angle_shortest = q_rotated.angleShortestPath(q_identity);
+      //std::printf("angle(identity), angleShortestPath(identity):\n");
+      std::printf("               angle(identity): %.3f @ [%.3f, %.3f, %.3f] \n",
+                  angle_out, axis_out.x(), axis_out.y(), axis_out.z());
+      std::printf("   angleShortestPath(identity): %.3f\n",
+                  angle_shortest);
+
+      // Compute and print the axis/angle of this quaternion (from identity is implied)
+      angle_out = q_rotated.getAngle();
+      angle_shortest = q_rotated.getAngleShortestPath();
+      //std::printf("getAngle(), getAngleShortestPath() :\n");
+      std::printf("                    getAngle(): %.3f @ [%.3f, %.3f, %.3f] \n",
+                  angle_out, axis_out.x(), axis_out.y(), axis_out.z());
+      std::printf("        getAngleShortestPath(): %.3f\n",
+                  angle_shortest);
+    }
+  }
+
+  return 0;
+}
+
+


### PR DESCRIPTION
The key was to use `dot(getIdentity())`, not `dot(*this)`. The other changes are just minor cleanup to make it match the layout of `angleShortestPath`.

The test file I added prints out the input and output values for the quaternion, so it can be used to verify things if you are curious.

... On a related note, why does `angle` return the half-angle, while `getAngle` return the angle of rotation? (The second one is the behavior I would expect... I can imagine a number of people get bitten by this "bug".)
