### PR TITLE
Fixes #11: orocos_kdl now has cmake rules oroco-kdl

### DIFF
--- a/eigen_conversions/CMakeLists.txt
+++ b/eigen_conversions/CMakeLists.txt
@@ -2,15 +2,17 @@ cmake_minimum_required(VERSION 2.8)
 project(eigen_conversions)
 
 find_package(Eigen REQUIRED)
-find_package(catkin REQUIRED geometry_msgs orocos_kdl std_msgs)
+find_package(orocos_kdl REQUIRED)
+find_package(catkin REQUIRED geometry_msgs std_msgs)
 
 include_directories(SYSTEM ${EIGEN_INCLUDE_DIRS})
-include_directories(include ${catkin_INCLUDE_DIRS})
+include_directories(include ${catkin_INCLUDE_DIRS} ${orocos_kdl_INCLUDE_DIRS})
 
 catkin_package(
   INCLUDE_DIRS include ${EIGEN_INCLUDE_DIRS}
   LIBRARIES ${PROJECT_NAME}
-  CATKIN_DEPENDS geometry_msgs orocos_kdl std_msgs
+  CATKIN_DEPENDS geometry_msgs std_msgs
+  DEPENDS orocos_kdl
 )
 
 add_library(${PROJECT_NAME}
@@ -18,7 +20,7 @@ add_library(${PROJECT_NAME}
   src/eigen_kdl.cpp
 )
 add_dependencies(${PROJECT_NAME} geometry_msgs_gencpp)
-target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${orocos_kdl_LIBRARIES})
 
 install(DIRECTORY include/${PROJECT_NAME}/
   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})

--- a/kdl_conversions/CMakeLists.txt
+++ b/kdl_conversions/CMakeLists.txt
@@ -1,21 +1,22 @@
 cmake_minimum_required(VERSION 2.8)
 project(kdl_conversions)
 
-find_package(catkin REQUIRED geometry_msgs orocos_kdl)
-
+find_package(catkin REQUIRED geometry_msgs)
+find_package(orocos_kdl REQUIRED)
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES ${PROJECT_NAME}
-  CATKIN_DEPENDS geometry_msgs orocos_kdl
+  CATKIN_DEPENDS geometry_msgs 
+  DEPENDS orocos_kdl
 )
 
-include_directories(include ${catkin_INCLUDE_DIRS})
+include_directories(include ${catkin_INCLUDE_DIRS} ${orocos_kdl_INCLUDE_DIRS})
 
 add_library(${PROJECT_NAME}
   src/kdl_msg.cpp
 )
 add_dependencies(${PROJECT_NAME} geometry_msgs_gencpp)
-target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${orocos_kdl_LIBRARIES})
 
 install(DIRECTORY include/${PROJECT_NAME}/
   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})


### PR DESCRIPTION
update cmake to use orocos_kdl as plain cmake package instead of catkin package

Signed-off-by: Ruben Smits ruben.smits@intermodalics.eu
