### PR TITLE
Fix deadlock with `rosbag play --clock --loop`

### DIFF
--- a/tf/src/tf.cpp
+++ b/tf/src/tf.cpp
@@ -604,7 +604,7 @@ bool Transformer::waitForTransform(const std::string& target_frame, const std::s
   std::string mapped_tgt = assert_resolved(tf_prefix_, target_frame);
   std::string mapped_src = assert_resolved(tf_prefix_, source_frame);
 
-  while (ok() && (now() - start_time) < timeout)
+  while (ok() && now() > start_time && (now() - start_time) < timeout)
   {
 	  if (frameExists(mapped_tgt) && frameExists(mapped_src) && (canTransform(mapped_tgt, mapped_src, time, error_msg)))
 		  return true;


### PR DESCRIPTION
The short desc gives it all away: If you loop a bag with /use_sim_time=true 
you can (and regularly will) end up with a deadlock here: All times published
on /clock are before the expected timeout.
