### PR TITLE
Wait for transform fix fix fuerte

### DIFF
--- a/tf/src/tf.cpp
+++ b/tf/src/tf.cpp
@@ -604,7 +604,7 @@ bool Transformer::waitForTransform(const std::string& target_frame, const std::s
   std::string mapped_tgt = assert_resolved(tf_prefix_, target_frame);
   std::string mapped_src = assert_resolved(tf_prefix_, source_frame);
 
-  while (ok() && now() > start_time && (now() - start_time) < timeout)
+  while (ok() && now() >= start_time && (now() - start_time) < timeout)
   {
 	  if (frameExists(mapped_tgt) && frameExists(mapped_src) && (canTransform(mapped_tgt, mapped_src, time, error_msg)))
 		  return true;


### PR DESCRIPTION
Sorry, but I just found a racing condition which didn't hit me earlier when writing the last patch.
However, it is quite severe as it can break waitForTransform altogether and not just on loops.
Please merge that one _before_ building (the last?) official packages for fuerte.
Sorry again...
