### PR TITLE
Fix const correctness of tf::Vector3 rotate() method

### DIFF
--- a/tf/include/tf/LinearMath/Vector3.h
+++ b/tf/include/tf/LinearMath/Vector3.h
@@ -156,7 +156,7 @@ public:
   /**@brief Rotate this vector 
    * @param wAxis The axis to rotate about 
    * @param angle The angle to rotate by */
-	TFSIMD_FORCE_INLINE Vector3 rotate( const Vector3& wAxis, const tfScalar angle );
+	TFSIMD_FORCE_INLINE Vector3 rotate( const Vector3& wAxis, const tfScalar angle ) const;
 
   /**@brief Return the angle between this and another vector
    * @param v The other vector */
@@ -473,7 +473,7 @@ TFSIMD_FORCE_INLINE Vector3 Vector3::normalized() const
 	return *this / length();
 } 
 
-TFSIMD_FORCE_INLINE Vector3 Vector3::rotate( const Vector3& wAxis, const tfScalar angle )
+TFSIMD_FORCE_INLINE Vector3 Vector3::rotate( const Vector3& wAxis, const tfScalar angle ) const
 {
 	// wAxis must be a unit lenght vector
 


### PR DESCRIPTION
The method does not modify the class thus should be const.
This has already been fixed in Bullet itself.
