### PR TITLE
Add rosconsole as runtime dependency

### DIFF
--- a/tf/CMakeLists.txt
+++ b/tf/CMakeLists.txt
@@ -22,7 +22,7 @@ generate_messages(DEPENDENCIES geometry_msgs sensor_msgs std_msgs)
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES ${PROJECT_NAME}
-  CATKIN_DEPENDS geometry_msgs message_filters message_runtime roscpp sensor_msgs std_msgs tf2_ros
+  CATKIN_DEPENDS geometry_msgs message_filters message_runtime roscpp sensor_msgs std_msgs tf2_ros rosconsole
 )
 
 add_library(${PROJECT_NAME} src/tf.cpp src/transform_listener.cpp src/cache.cpp src/transform_broadcaster.cpp)

--- a/tf/package.xml
+++ b/tf/package.xml
@@ -36,6 +36,7 @@ any desired point in time.
   <run_depend>graphviz</run_depend>
   <run_depend>message_filters</run_depend>
   <run_depend>message_runtime</run_depend>
+  <run_depend>rosconsole</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>roswtf</run_depend>
   <run_depend>sensor_msgs</run_depend>


### PR DESCRIPTION
Using tf directly with CMake without catkin yields a link error for ros::console::print. This fixes it.
