### PR TITLE
TF uses ros::MessageEvent to get connection information

### DIFF
--- a/tf/include/tf/message_filter.h
+++ b/tf/include/tf/message_filter.h
@@ -336,7 +336,7 @@ private:
   bool testMessage(const MEvent& evt)
   {
     const MConstPtr& message = evt.getMessage();
-    std::string callerid = evt.getPublisherName();//message->__connection_header ? (*message->__connection_header)["callerid"] : "unknown";
+    std::string callerid = evt.getPublisherName();
     std::string frame_id = ros::message_traits::FrameId<M>::value(*message);
     ros::Time stamp = ros::message_traits::TimeStamp<M>::value(*message);
 

--- a/tf/src/tf_monitor.cpp
+++ b/tf/src/tf_monitor.cpp
@@ -63,23 +63,10 @@ public:
   tf::tfMessage message_;
 
   boost::mutex map_lock_;
-  void callback(const tf::tfMessageConstPtr& msg_ptr)
+  void callback(const ros::MessageEvent<tf::tfMessage>& msg_evt)
   {
-    const tf::tfMessage& message = *msg_ptr;
-    //Lookup the authority 
-    std::string authority;
-    std::map<std::string, std::string>* msg_header_map = message.__connection_header.get();
-    std::map<std::string, std::string>::iterator it = msg_header_map->find("callerid");
-    if (it == msg_header_map->end())
-    {
-      ROS_WARN("Message recieved without callerid");
-      authority = "no callerid";
-    }
-    else
-    {
-      authority = it->second;
-    }
-
+    const tf::tfMessage& message = *(msg_evt.getConstMessage());
+    std::string authority = msg_evt.getPublisherName(); // lookup the authority 
 
     double average_offset = 0;
     boost::mutex::scoped_lock my_lock(map_lock_);  


### PR DESCRIPTION
TF should stop using the "__connection_header" field of ROS messages, but instead use the ros::MessageEvent.
