### PR TITLE
Created TransformerHelper

### DIFF
--- a/tf/include/tf/transform_listener.h
+++ b/tf/include/tf/transform_listener.h
@@ -65,8 +65,97 @@ inline std::string getPrefixParam(ros::NodeHandle & nh) {
  * \deprecated Use TransformListener::remap  instead */
 std::string remap(const std::string& frame_id) __attribute__((deprecated));
 
+
+class TransformerHelper: public Transformer {
+
+public:
+  TransformerHelper(ros::Duration max_cache_time = ros::Duration(DEFAULT_CACHE_TIME));
+
+  virtual ~TransformerHelper();
+
+  /* Methods from transformer unhiding them here */
+  using Transformer::transformQuaternion;
+  using Transformer::transformVector;
+  using Transformer::transformPoint;
+  using Transformer::transformPose;
+
+
+  /** \brief Transform a Stamped Quaternion Message into the target frame
+   * This can throw all that lookupTransform can throw as well as tf::InvalidTransform */
+  void transformQuaternion(const std::string& target_frame, const geometry_msgs::QuaternionStamped& stamped_in, geometry_msgs::QuaternionStamped& stamped_out) const;
+  /** \brief Transform a Stamped Vector Message into the target frame
+   * This can throw all that lookupTransform can throw as well as tf::InvalidTransform */
+  void transformVector(const std::string& target_frame, const geometry_msgs::Vector3Stamped& stamped_in, geometry_msgs::Vector3Stamped& stamped_out) const;
+  /** \brief Transform a Stamped Point Message into the target frame
+   * This can throw all that lookupTransform can throw as well as tf::InvalidTransform */
+  void transformPoint(const std::string& target_frame, const geometry_msgs::PointStamped& stamped_in, geometry_msgs::PointStamped& stamped_out) const;
+  /** \brief Transform a Stamped Pose Message into the target frame
+   * This can throw all that lookupTransform can throw as well as tf::InvalidTransform */
+  void transformPose(const std::string& target_frame, const geometry_msgs::PoseStamped& stamped_in, geometry_msgs::PoseStamped& stamped_out) const;
+
+  /** \brief Transform a Stamped Twist Message into the target frame
+   * This can throw all that lookupTransform can throw as well as tf::InvalidTransform */
+  // http://www.ros.org/wiki/tf/Reviews/2010-03-12_API_Review
+  //  void transformTwist(const std::string& target_frame, const geometry_msgs::TwistStamped& stamped_in, geometry_msgs::TwistStamped& stamped_out) const;
+
+  /** \brief Transform a Stamped Quaternion Message into the target frame
+   * This can throw all that lookupTransform can throw as well as tf::InvalidTransform */
+  void transformQuaternion(const std::string& target_frame, const ros::Time& target_time,
+                           const geometry_msgs::QuaternionStamped& qin,
+                           const std::string& fixed_frame, geometry_msgs::QuaternionStamped& qout) const;
+  /** \brief Transform a Stamped Vector Message into the target frame and time
+   * This can throw all that lookupTransform can throw as well as tf::InvalidTransform */
+  void transformVector(const std::string& target_frame, const ros::Time& target_time,
+                       const geometry_msgs::Vector3Stamped& vin,
+                           const std::string& fixed_frame, geometry_msgs::Vector3Stamped& vout) const;
+  /** \brief Transform a Stamped Point Message into the target frame and time
+   * This can throw all that lookupTransform can throw as well as tf::InvalidTransform */
+  void transformPoint(const std::string& target_frame, const ros::Time& target_time,
+                           const geometry_msgs::PointStamped& pin,
+                           const std::string& fixed_frame, geometry_msgs::PointStamped& pout) const;
+  /** \brief Transform a Stamped Pose Message into the target frame and time
+   * This can throw all that lookupTransform can throw as well as tf::InvalidTransform */
+  void transformPose(const std::string& target_frame, const ros::Time& target_time,
+                     const geometry_msgs::PoseStamped& pin,
+                     const std::string& fixed_frame, geometry_msgs::PoseStamped& pout) const;
+
+
+  /** \brief Transform a sensor_msgs::PointCloud natively
+   * This can throw all that lookupTransform can throw as well as tf::InvalidTransform */
+    void transformPointCloud(const std::string& target_frame, const sensor_msgs::PointCloud& pcin, sensor_msgs::PointCloud& pcout) const;
+
+  /** @brief Transform a sensor_msgs::PointCloud in space and time
+   * This can throw all that lookupTransform can throw as well as tf::InvalidTransform */
+  void transformPointCloud(const std::string& target_frame, const ros::Time& target_time,
+                           const sensor_msgs::PointCloud& pcin,
+                           const std::string& fixed_frame, sensor_msgs::PointCloud& pcout) const;
+
+
+
+    ///\todo move to high precision laser projector class  void projectAndTransformLaserScan(const sensor_msgs::LaserScan& scan_in, sensor_msgs::PointCloud& pcout);
+
+  bool getFrames(tf::FrameGraph::Request& req, tf::FrameGraph::Response& res)
+  {
+    res.dot_graph = allFramesAsDot();
+    return true;
+  }
+
+  /* \brief Resolve frame_name into a frame_id using tf_prefix parameter */
+  std::string resolve(const std::string& frame_name)
+  {
+    ros::NodeHandle n("~");
+    std::string prefix = tf::getPrefixParam(n);
+    return tf::resolve(prefix, frame_name);
+  }
+
+private:
+  /** @brief a helper function to be used for both transfrom pointCloud methods */
+  void transformPointCloud(const std::string & target_frame, const Transform& transform, const ros::Time& target_time, const sensor_msgs::PointCloud& pcin, sensor_msgs::PointCloud& pcout) const;
+};
+
+
 /** \brief This class inherits from Transformer and automatically subscribes to ROS transform messages */
-class TransformListener : public Transformer { //subscribes to message and automatically stores incoming data
+class TransformListener : public TransformerHelper { //subscribes to message and automatically stores incoming data
 
 public:
   /**@brief Constructor for transform listener
@@ -83,81 +172,6 @@ public:
   
   ~TransformListener();
 
-  /* Methods from transformer unhiding them here */
-  using Transformer::transformQuaternion;
-  using Transformer::transformVector;
-  using Transformer::transformPoint;
-  using Transformer::transformPose;
-
-
-  /** \brief Transform a Stamped Quaternion Message into the target frame 
-   * This can throw all that lookupTransform can throw as well as tf::InvalidTransform */
-  void transformQuaternion(const std::string& target_frame, const geometry_msgs::QuaternionStamped& stamped_in, geometry_msgs::QuaternionStamped& stamped_out) const;
-  /** \brief Transform a Stamped Vector Message into the target frame 
-   * This can throw all that lookupTransform can throw as well as tf::InvalidTransform */
-  void transformVector(const std::string& target_frame, const geometry_msgs::Vector3Stamped& stamped_in, geometry_msgs::Vector3Stamped& stamped_out) const;
-  /** \brief Transform a Stamped Point Message into the target frame 
-   * This can throw all that lookupTransform can throw as well as tf::InvalidTransform */
-  void transformPoint(const std::string& target_frame, const geometry_msgs::PointStamped& stamped_in, geometry_msgs::PointStamped& stamped_out) const;
-  /** \brief Transform a Stamped Pose Message into the target frame 
-   * This can throw all that lookupTransform can throw as well as tf::InvalidTransform */
-  void transformPose(const std::string& target_frame, const geometry_msgs::PoseStamped& stamped_in, geometry_msgs::PoseStamped& stamped_out) const;
-
-  /** \brief Transform a Stamped Twist Message into the target frame 
-   * This can throw all that lookupTransform can throw as well as tf::InvalidTransform */
-  // http://www.ros.org/wiki/tf/Reviews/2010-03-12_API_Review
-  //  void transformTwist(const std::string& target_frame, const geometry_msgs::TwistStamped& stamped_in, geometry_msgs::TwistStamped& stamped_out) const;
-
-  /** \brief Transform a Stamped Quaternion Message into the target frame
-   * This can throw all that lookupTransform can throw as well as tf::InvalidTransform */
-  void transformQuaternion(const std::string& target_frame, const ros::Time& target_time,
-                           const geometry_msgs::QuaternionStamped& qin,
-                           const std::string& fixed_frame, geometry_msgs::QuaternionStamped& qout) const;
-  /** \brief Transform a Stamped Vector Message into the target frame and time 
-   * This can throw all that lookupTransform can throw as well as tf::InvalidTransform */
-  void transformVector(const std::string& target_frame, const ros::Time& target_time,
-                       const geometry_msgs::Vector3Stamped& vin,
-                           const std::string& fixed_frame, geometry_msgs::Vector3Stamped& vout) const;
-  /** \brief Transform a Stamped Point Message into the target frame and time  
-   * This can throw all that lookupTransform can throw as well as tf::InvalidTransform */
-  void transformPoint(const std::string& target_frame, const ros::Time& target_time,
-                           const geometry_msgs::PointStamped& pin,
-                           const std::string& fixed_frame, geometry_msgs::PointStamped& pout) const;
-  /** \brief Transform a Stamped Pose Message into the target frame and time  
-   * This can throw all that lookupTransform can throw as well as tf::InvalidTransform */
-  void transformPose(const std::string& target_frame, const ros::Time& target_time,
-                     const geometry_msgs::PoseStamped& pin,
-                     const std::string& fixed_frame, geometry_msgs::PoseStamped& pout) const;
-
-
-  /** \brief Transform a sensor_msgs::PointCloud natively 
-   * This can throw all that lookupTransform can throw as well as tf::InvalidTransform */
-    void transformPointCloud(const std::string& target_frame, const sensor_msgs::PointCloud& pcin, sensor_msgs::PointCloud& pcout) const;
-
-  /** @brief Transform a sensor_msgs::PointCloud in space and time 
-   * This can throw all that lookupTransform can throw as well as tf::InvalidTransform */
-  void transformPointCloud(const std::string& target_frame, const ros::Time& target_time,
-                           const sensor_msgs::PointCloud& pcin,
-                           const std::string& fixed_frame, sensor_msgs::PointCloud& pcout) const;
-
-
-
-    ///\todo move to high precision laser projector class  void projectAndTransformLaserScan(const sensor_msgs::LaserScan& scan_in, sensor_msgs::PointCloud& pcout);
-
-  bool getFrames(tf::FrameGraph::Request& req, tf::FrameGraph::Response& res) 
-  {
-    res.dot_graph = allFramesAsDot();
-    return true;
-  }
-
-  /* \brief Resolve frame_name into a frame_id using tf_prefix parameter */
-  std::string resolve(const std::string& frame_name)
-  {
-    ros::NodeHandle n("~");
-    std::string prefix = tf::getPrefixParam(n);
-    return tf::resolve(prefix, frame_name);
-  };
-
 protected:
   bool ok() const;
 
@@ -168,10 +182,6 @@ private:
 
   /// replacing implementation with tf2_ros'
   tf2_ros::TransformListener tf2_listener_;
-
-  /** @brief a helper function to be used for both transfrom pointCloud methods */
-  void transformPointCloud(const std::string & target_frame, const Transform& transform, const ros::Time& target_time, const sensor_msgs::PointCloud& pcin, sensor_msgs::PointCloud& pcout) const;
-
 };
 }
 

--- a/tf/src/transform_listener.cpp
+++ b/tf/src/transform_listener.cpp
@@ -40,44 +40,33 @@ std::string tf::remap(const std::string& frame_id)
 {
   ros::NodeHandle n("~");
   return tf::resolve(getPrefixParam(n), frame_id);
-};
-
-
-TransformListener::TransformListener(ros::Duration max_cache_time, bool spin_thread):
-  Transformer(true, max_cache_time), tf2_listener_(Transformer::tf2_buffer_, node_, spin_thread)
-{
-  //Everything is done inside tf2 init
 }
 
-TransformListener::TransformListener(const ros::NodeHandle& nh, ros::Duration max_cache_time, bool spin_thread):
-  Transformer(true, max_cache_time), node_(nh), tf2_listener_(Transformer::tf2_buffer_, nh, spin_thread)
+
+TransformerHelper::TransformerHelper(ros::Duration max_cache_time)
+  : Transformer(true, max_cache_time)
 {
-  //Everything is done inside tf2 init
+
 }
 
-TransformListener::~TransformListener()
+TransformerHelper::~TransformerHelper()
 {
-  //Everything is done inside tf2 init
+
 }
 
-//Override Transformer::ok() for ticket:4882
-bool TransformListener::ok() const { return ros::ok(); }
-
-
-
-void TransformListener::transformQuaternion(const std::string& target_frame,
+void TransformerHelper::transformQuaternion(const std::string& target_frame,
     const geometry_msgs::QuaternionStamped& msg_in,
     geometry_msgs::QuaternionStamped& msg_out) const
 {
   tf::assertQuaternionValid(msg_in.quaternion);
 
   Stamped<Quaternion> pin, pout;
-  quaternionStampedMsgToTF(msg_in, pin);  
+  quaternionStampedMsgToTF(msg_in, pin);
   transformQuaternion(target_frame, pin, pout);
   quaternionStampedTFToMsg(pout, msg_out);
 }
 
-void TransformListener::transformVector(const std::string& target_frame,
+void TransformerHelper::transformVector(const std::string& target_frame,
     const geometry_msgs::Vector3Stamped& msg_in,
     geometry_msgs::Vector3Stamped& msg_out) const
 {
@@ -87,7 +76,7 @@ void TransformListener::transformVector(const std::string& target_frame,
   vector3StampedTFToMsg(pout, msg_out);
 }
 
-void TransformListener::transformPoint(const std::string& target_frame,
+void TransformerHelper::transformPoint(const std::string& target_frame,
     const geometry_msgs::PointStamped& msg_in,
     geometry_msgs::PointStamped& msg_out) const
 {
@@ -97,7 +86,7 @@ void TransformListener::transformPoint(const std::string& target_frame,
   pointStampedTFToMsg(pout, msg_out);
 }
 
-void TransformListener::transformPose(const std::string& target_frame,
+void TransformerHelper::transformPose(const std::string& target_frame,
     const geometry_msgs::PoseStamped& msg_in,
     geometry_msgs::PoseStamped& msg_out) const
 {
@@ -109,7 +98,7 @@ void TransformListener::transformPose(const std::string& target_frame,
   poseStampedTFToMsg(pout, msg_out);
 }
 /* http://www.ros.org/wiki/tf/Reviews/2010-03-12_API_Review
-void TransformListener::transformTwist(const std::string& target_frame,
+void TransformerHelper::transformTwist(const std::string& target_frame,
     const geometry_msgs::TwistStamped& msg_in,
     geometry_msgs::TwistStamped& msg_out) const
 {
@@ -141,7 +130,7 @@ void TransformListener::transformTwist(const std::string& target_frame,
 
   }*/
 
-void TransformListener::transformQuaternion(const std::string& target_frame, const ros::Time& target_time,
+void TransformerHelper::transformQuaternion(const std::string& target_frame, const ros::Time& target_time,
     const geometry_msgs::QuaternionStamped& msg_in,
     const std::string& fixed_frame, geometry_msgs::QuaternionStamped& msg_out) const
 {
@@ -152,7 +141,7 @@ void TransformListener::transformQuaternion(const std::string& target_frame, con
   quaternionStampedTFToMsg(pout, msg_out);
 }
 
-void TransformListener::transformVector(const std::string& target_frame, const ros::Time& target_time,
+void TransformerHelper::transformVector(const std::string& target_frame, const ros::Time& target_time,
     const geometry_msgs::Vector3Stamped& msg_in,
     const std::string& fixed_frame, geometry_msgs::Vector3Stamped& msg_out) const
 {
@@ -162,7 +151,7 @@ void TransformListener::transformVector(const std::string& target_frame, const r
   vector3StampedTFToMsg(pout, msg_out);
 }
 
-void TransformListener::transformPoint(const std::string& target_frame, const ros::Time& target_time,
+void TransformerHelper::transformPoint(const std::string& target_frame, const ros::Time& target_time,
     const geometry_msgs::PointStamped& msg_in,
     const std::string& fixed_frame, geometry_msgs::PointStamped& msg_out) const
 {
@@ -172,7 +161,7 @@ void TransformListener::transformPoint(const std::string& target_frame, const ro
   pointStampedTFToMsg(pout, msg_out);
 }
 
-void TransformListener::transformPose(const std::string& target_frame, const ros::Time& target_time,
+void TransformerHelper::transformPose(const std::string& target_frame, const ros::Time& target_time,
     const geometry_msgs::PoseStamped& msg_in,
     const std::string& fixed_frame, geometry_msgs::PoseStamped& msg_out) const
 {
@@ -184,14 +173,14 @@ void TransformListener::transformPose(const std::string& target_frame, const ros
   poseStampedTFToMsg(pout, msg_out);
 }
 
-void TransformListener::transformPointCloud(const std::string & target_frame, const sensor_msgs::PointCloud & cloudIn, sensor_msgs::PointCloud & cloudOut) const
+void TransformerHelper::transformPointCloud(const std::string & target_frame, const sensor_msgs::PointCloud & cloudIn, sensor_msgs::PointCloud & cloudOut) const
 {
   StampedTransform transform;
   lookupTransform(target_frame, cloudIn.header.frame_id, cloudIn.header.stamp, transform);
 
   transformPointCloud(target_frame, transform, cloudIn.header.stamp, cloudIn, cloudOut);
 }
-void TransformListener::transformPointCloud(const std::string& target_frame, const ros::Time& target_time, 
+void TransformerHelper::transformPointCloud(const std::string& target_frame, const ros::Time& target_time,
     const sensor_msgs::PointCloud& cloudIn,
     const std::string& fixed_frame, sensor_msgs::PointCloud& cloudOut) const
 {
@@ -212,13 +201,13 @@ inline void transformPointMatVec(const tf::Vector3 &origin, const tf::Matrix3x3 
   double x = basis[0].x() * in.x + basis[0].y() * in.y + basis[0].z() * in.z + origin.x();
   double y = basis[1].x() * in.x + basis[1].y() * in.y + basis[1].z() * in.z + origin.y();
   double z = basis[2].x() * in.x + basis[2].y() * in.y + basis[2].z() * in.z + origin.z();
-  
+
   out.x = x; out.y = y; out.z = z;
 }
 
 
-void TransformListener::transformPointCloud(const std::string & target_frame, const tf::Transform& net_transform,
-                                            const ros::Time& target_time, const sensor_msgs::PointCloud & cloudIn, 
+void TransformerHelper::transformPointCloud(const std::string & target_frame, const tf::Transform& net_transform,
+                                            const ros::Time& target_time, const sensor_msgs::PointCloud & cloudIn,
                                             sensor_msgs::PointCloud & cloudOut) const
 {
   tf::Vector3 origin = net_transform.getOrigin();
@@ -247,3 +236,22 @@ void TransformListener::transformPointCloud(const std::string & target_frame, co
 
 
 
+TransformListener::TransformListener(ros::Duration max_cache_time, bool spin_thread):
+  TransformerHelper(max_cache_time), tf2_listener_(Transformer::tf2_buffer_, node_, spin_thread)
+{
+  //Everything is done inside tf2 init
+}
+
+TransformListener::TransformListener(const ros::NodeHandle& nh, ros::Duration max_cache_time, bool spin_thread):
+  TransformerHelper(max_cache_time), node_(nh), tf2_listener_(Transformer::tf2_buffer_, nh, spin_thread)
+{
+  //Everything is done inside tf2 init
+}
+
+TransformListener::~TransformListener()
+{
+  //Everything is done inside tf2 init
+}
+
+//Override Transformer::ok() for ticket:4882
+bool TransformListener::ok() const { return ros::ok(); }


### PR DESCRIPTION
It stands between Transformer and TransformListener. It decouples the
2 functionalities of the TransformListener class: listen to transforms
and provide helper functions to transform data.

This seems trivial, but in my case it's very important to decouple the 2. My code is designed this way: libraries that can be used offline, and online node that wrap those libraries in a communicating ROS framework. In the offline case I really want to use the helper functions from TransformListener to transform my data, but I don't want to be listening to incoming transforms (transforms are pushed manually inside the transformer).

I tested it with my large code base. It can be used as is. And I tested the decoupling, it works. So it seems to be pretty safe modification to me.
