### PR TITLE
Python 3 support

### DIFF
--- a/tf/CMakeLists.txt
+++ b/tf/CMakeLists.txt
@@ -99,7 +99,7 @@ endif()
 
 
 #Python setup
-set(Python_ADDITIONAL_VERSIONS 2.7)
+set(Python_ADDITIONAL_VERSIONS "${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}")
 find_package(PythonLibs REQUIRED)
 include_directories(${PYTHON_INCLUDE_PATH})
 

--- a/tf/scripts/python_benchmark.py
+++ b/tf/scripts/python_benchmark.py
@@ -40,7 +40,11 @@ import numpy
 import unittest
 import sys
 import time
-import StringIO
+try:
+    from cStringIO import StringIO
+except ImportError:
+    from io import StringIO
+
 
 import tf.transformations
 import geometry_msgs.msg
@@ -63,7 +67,7 @@ def mkm():
 tm = tfMessage([mkm() for i in range(20)])
 
 def deserel_to_string(o):
-    s = StringIO.StringIO()
+    s = StringIO()
     o.serialize(s)
     return s.getvalue()
 
@@ -74,7 +78,7 @@ class Timer:
         self.func = func
     def mean(self, iterations = 1000000):
         started = time.time()
-        for i in xrange(iterations):
+        for i in range(iterations):
             self.func()
         took = time.time() - started
         return took / iterations
@@ -94,14 +98,14 @@ for t in [tf.msg.tfMessage, tf.cMsg.tfMessage]:
 sys.exit(0)
 
 started = time.time()
-for i in xrange(iterations):
+for i in range(iterations):
     for m in tm.transforms:
         t.setTransform(m)
 took = time.time() - started
 print("setTransform only", iterations, "took", took, "%f us each" % (1e6 * took / iterations))
 
 started = time.time()
-for i in xrange(iterations):
+for i in range(iterations):
     m2 = tfMessage()
     m2.deserialize(mstr)
     for m in m2.transforms:

--- a/tf/scripts/python_benchmark.py
+++ b/tf/scripts/python_benchmark.py
@@ -30,6 +30,8 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import print_function
+
 import roslib
 roslib.load_manifest('tf')
 import rostest
@@ -83,11 +85,11 @@ for t in [tf.msg.tfMessage, tf.cMsg.tfMessage]:
     m2 = t()
     m2.deserialize(mstr)
     for m in m2.transforms:
-        print type(m), sys.getrefcount(m)
+        print(type(m), sys.getrefcount(m))
     assert deserel_to_string(m2) == mstr, "deserel screwed up for type %s" % repr(t)
 
     m2 = t()
-    print "deserialize only ", 1e6 * Timer(lambda: m2.deserialize(mstr)).mean(), "us each"
+    print("deserialize only ", 1e6 * Timer(lambda: m2.deserialize(mstr)).mean(), "us each")
 
 sys.exit(0)
 
@@ -96,7 +98,7 @@ for i in xrange(iterations):
     for m in tm.transforms:
         t.setTransform(m)
 took = time.time() - started
-print "setTransform only", iterations, "took", took, "%f us each" % (1e6 * took / iterations)
+print("setTransform only", iterations, "took", took, "%f us each" % (1e6 * took / iterations))
 
 started = time.time()
 for i in xrange(iterations):
@@ -105,6 +107,6 @@ for i in xrange(iterations):
     for m in m2.transforms:
         t.setTransform(m)
 took = time.time() - started
-print "deserialize+setTransform ", iterations, "took", took, "%f us each" % (1e6 * took / iterations)
+print("deserialize+setTransform ", iterations, "took", took, "%f us each" % (1e6 * took / iterations))
 
 from tf import TransformListener

--- a/tf/scripts/tf_remap
+++ b/tf/scripts/tf_remap
@@ -35,6 +35,8 @@
 
 ## remap a tf topic
 
+from __future__ import print_function
+
 import roslib; roslib.load_manifest('tf')
 
 import rospy
@@ -50,7 +52,7 @@ class TfRemapper:
             if "old" in i and "new" in i:
                 self.mappings[i["old"]] = i["new"]
 
-        print "Applying the following mappings to incoming tf frame ids", self.mappings
+        print("Applying the following mappings to incoming tf frame ids", self.mappings)
         rospy.Subscriber("/tf_old", tfMessage, self.callback)
 
     def callback(self, tf_msg):

--- a/tf/scripts/view_frames
+++ b/tf/scripts/view_frames
@@ -91,7 +91,7 @@ def generate(dot_graph):
         args = ["dot", "-V"]
         try:
             vstr = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()[1]
-        except OSError, ex:
+        except OSError as ex:
             print("Warning: Could not execute `dot -V`.  Is graphviz installed?")
             sys.exit(-1)
         v = distutils.version.StrictVersion('2.16')

--- a/tf/scripts/view_frames
+++ b/tf/scripts/view_frames
@@ -36,7 +36,7 @@
 ## Simple demo of a rospy service client that calls a service to add
 ## two integers. 
 
-from __future__ import with_statement
+from __future__ import print_function, with_statement
 
 PKG = 'tf' # this package name
 
@@ -58,24 +58,24 @@ import tf
 def listen(duration):
     rospy.init_node("view_frames", anonymous=True)
     tf_listener = tf.TransformListener()
-    print "Listening to /tf for %f seconds"%duration
+    print("Listening to /tf for %f seconds"%duration)
     time.sleep(duration)
-    print "Done Listening"
+    print("Done Listening")
     return tf_listener.allFramesAsDot()
     
 
 def poll(node_name):
-    print "Waiting for service %s/tf_frames"%node_name
+    print("Waiting for service %s/tf_frames"%node_name)
     rospy.wait_for_service('%s/tf_frames'%node_name)
 
     try:
-        print "Polling service"
+        print("Polling service")
         tf_frames_proxy = rospy.ServiceProxy('%s/tf_frames'%node_name, FrameGraph)
 
         output = tf_frames_proxy.call(FrameGraphRequest())
 
     except rospy.ServiceException, e:
-        print "Service call failed: %s"%e
+        print("Service call failed: %s"%e)
         
     return output.dot_graph
 
@@ -92,25 +92,25 @@ def generate(dot_graph):
         try:
             vstr = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()[1]
         except OSError, ex:
-            print "Warning: Could not execute `dot -V`.  Is graphviz installed?"
+            print("Warning: Could not execute `dot -V`.  Is graphviz installed?")
             sys.exit(-1)
         v = distutils.version.StrictVersion('2.16')
         r = re.compile(".*version ([^ ]*).*")
-        print vstr
+        print(vstr)
         m = r.search(vstr)
         if not m or not m.group(1):
-          print 'Warning: failed to determine your version of dot.  Assuming v2.16'
+          print('Warning: failed to determine your version of dot.  Assuming v2.16')
         else:
           version = distutils.version.StrictVersion(m.group(1))
-          print 'Detected dot version %s' % (version)
+          print('Detected dot version %s' % (version))
         if version > distutils.version.StrictVersion('2.8'):
           subprocess.check_call(["dot", "-Tpdf", "frames.gv", "-o", "frames.pdf"])
-          print "frames.pdf generated"
+          print("frames.pdf generated")
         else:
           subprocess.check_call(["dot", "-Tps2", "frames.gv", "-o", "frames.ps"])
-          print "frames.ps generated"
+          print("frames.ps generated")
     except subprocess.CalledProcessError:
-        print >> sys.stderr, "failed to generate frames.pdf"        
+        print("failed to generate frames.pdf", file=sys.stderr)
 
 
 if __name__ == '__main__':
@@ -124,7 +124,7 @@ if __name__ == '__main__':
     if not options.node:
         dot_graph = listen(5.0)
     else:
-        print "Generating graph for node: ", options.node
+        print("Generating graph for node: ", options.node)
         dot_graph = poll(options.node)
 
     generate(dot_graph)

--- a/tf/src/tf/__init__.py
+++ b/tf/src/tf/__init__.py
@@ -25,6 +25,6 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from _tf import *
-from listener import TransformListener, TransformerROS
-from broadcaster import TransformBroadcaster
+from ._tf import *
+from .listener import TransformListener, TransformerROS
+from .broadcaster import TransformBroadcaster

--- a/tf/src/tf/tfwtf.py
+++ b/tf/src/tf/tfwtf.py
@@ -61,7 +61,7 @@ def rostime_delta(ctx):
                     deltas[callerid]  = secs
 
     errors = []
-    for k, v in deltas.iteritems():
+    for k, v in deltas.items():
         errors.append("receiving transform from [%s] that differed from ROS time by %ss"%(k, v))
     return errors
 

--- a/tf/src/tf/tfwtf.py
+++ b/tf/src/tf/tfwtf.py
@@ -165,11 +165,11 @@ def roswtf_plugin_online(ctx):
     if not is_tf_active():
         return
     
-    print "running tf checks, this will take a second..."
+    print("running tf checks, this will take a second...")
     sub1 = rospy.Subscriber('/tf', tf.msg.tfMessage, _tf_handle)
     time.sleep(1.0)
     sub1.unregister()
-    print "... tf checks complete"    
+    print("... tf checks complete")
 
     for r in tf_warnings:
         warning_rule(r, r[0](ctx), ctx)

--- a/tf/test/method_test.py
+++ b/tf/test/method_test.py
@@ -41,5 +41,5 @@ try:
     print("After assignment of Rotation Transformation")
     print(transform_stamped.transform)
     
-except ValueError, e:
+except ValueError as e:
     print("Exception %s Improperly thrown: %s"%(type(e), e))

--- a/tf/test/method_test.py
+++ b/tf/test/method_test.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import roslib; roslib.load_manifest("tf")
 
 import rospy
@@ -9,35 +11,35 @@ import math
 
 try:
     transform_stamped = tf.TransformStamped()
-    print "getting stamp"
-    print transform_stamped.stamp
+    print("getting stamp")
+    print(transform_stamped.stamp)
 #    mytime = rospy.Time().now()
     mytime = rospy.Time(10,20)
     transform_stamped.stamp = mytime
-    print mytime
-    print "getting stamp", transform_stamped.stamp
-    print "transform:", transform_stamped.transform
+    print(mytime)
+    print("getting stamp", transform_stamped.stamp)
+    print("transform:", transform_stamped.transform)
     transform_stamped.transform.setIdentity()
-    print "after setIdentity()", transform_stamped.transform
+    print("after setIdentity()", transform_stamped.transform)
     #    transform_stamped.transform.basis.setEulerZYX(0,0,0)
     quat = bullet.Quaternion(math.pi/2,0,0)
-    print "quaternion ", quat
+    print("quaternion ", quat)
     transform_stamped.transform.setRotation(quat)
-    print "setting rotation to PI/2\n After setRotation"
-    print transform_stamped.transform
+    print("setting rotation to PI/2\n After setRotation")
+    print(transform_stamped.transform)
 
     other_transform = bullet.Transform()
     other_transform.setIdentity()
     transform_stamped.transform = other_transform
-    print "After assignment of Identity"
-    print transform_stamped.transform
+    print("After assignment of Identity")
+    print(transform_stamped.transform)
 
     other_transform = bullet.Transform()
     other_transform.setIdentity()
     other_transform.setRotation(quat)
     transform_stamped.transform = other_transform
-    print "After assignment of Rotation Transformation"
-    print transform_stamped.transform
+    print("After assignment of Rotation Transformation")
+    print(transform_stamped.transform)
     
 except ValueError, e:
-    print "Exception %s Improperly thrown: %s"%(type(e), e)
+    print("Exception %s Improperly thrown: %s"%(type(e), e))

--- a/tf/test/python_debug_test.py
+++ b/tf/test/python_debug_test.py
@@ -153,7 +153,7 @@ try:
 
     print("done")
 
-except ValueError, e:
+except ValueError as e:
     print("Exception %s Improperly thrown: %s"%(type(e), e))
 
 

--- a/tf/test/python_debug_test.py
+++ b/tf/test/python_debug_test.py
@@ -25,6 +25,8 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import print_function
+
 import roslib; roslib.load_manifest("tf")
 
 import rospy
@@ -40,108 +42,108 @@ try:
     time.sleep(1)
 
     # View all frames
-    print "All frames are:\n", tfl.all_frames_as_string()
+    print("All frames are:\n", tfl.all_frames_as_string())
 
     # dot based introspection
-    print "All frame graph is:\n", tfl.all_frames_as_dot()
+    print("All frame graph is:\n", tfl.all_frames_as_dot())
 
     
     # test transforming pose
     po = tf.PoseStamped()
     po.frame_id = "base_link"
-    print "calling transform pose"
+    print("calling transform pose")
     po2 = tfl.transform_pose("/map", po)
 
-    print "po2.pose.this", po2.pose.this
-    print "po.pose.this", po.pose.this
+    print("po2.pose.this", po2.pose.this)
+    print("po.pose.this", po.pose.this)
 
     # test transforming point
     po = tf.PointStamped()
     po.frame_id = "base_link"
     po3 = tfl.transform_point("/map", po)
-    print "po3"
-    print po3.this
+    print("po3")
+    print(po3.this)
 
     # test transforming vector
     po = tf.VectorStamped()
     po.frame_id = "base_link"
     po4 = tfl.transform_vector("/map", po)
-    print po4.this
+    print(po4.this)
     
     # test transforming quaternion
     po = tf.QuaternionStamped()
     po.frame_id = "base_link"
     po5 = tfl.transform_quaternion("/map", po)
-    print "po5",  po5.this
+    print("po5",  po5.this)
     
     tr = tf.TransformStamped()
 
     lps = tf.PoseStamped()
     lps.pose.setIdentity()
-    print "setting stamp"
+    print("setting stamp")
     mytime = rospy.Time(10,20)
     lps.stamp = mytime
-    print mytime
-    print "getting stamp"
+    print(mytime)
+    print("getting stamp")
     output = lps.stamp
-    print output
-    print lps.pose
-    print "setting pose.positon to 1,2,3"
+    print(output)
+    print(lps.pose)
+    print("setting pose.positon to 1,2,3")
     lps.pose.setOrigin( bullet.Vector3(1,2,3))
-    print lps.pose.getOrigin()
-    print lps.pose    
+    print(lps.pose.getOrigin())
+    print(lps.pose)
 
     transform_stamped = tf.TransformStamped()
-    print "getting stamp"
-    print transform_stamped.stamp
+    print("getting stamp")
+    print(transform_stamped.stamp)
 #    mytime = rospy.Time().now()
     mytime = rospy.Time(10,20)
     transform_stamped.stamp = mytime
-    print mytime
-    print "getting stamp", transform_stamped.stamp
-    print "transform:", transform_stamped.transform
+    print(mytime)
+    print("getting stamp", transform_stamped.stamp)
+    print("transform:", transform_stamped.transform)
     transform_stamped.transform.setIdentity()
-    print "after setIdentity()", transform_stamped.transform
+    print("after setIdentity()", transform_stamped.transform)
     #    transform_stamped.transform.basis.setEulerZYX(0,0,0)
     quat = bullet.Quaternion(math.pi/2,0,0)
-    print "quaternion ", quat
+    print("quaternion ", quat)
     transform_stamped.transform.setRotation(quat)
-    print "setting rotation to PI/2",transform_stamped.transform
+    print("setting rotation to PI/2",transform_stamped.transform)
 
 
     pointstamped = tf.PointStamped()
-    print "getting stamp"
-    print pointstamped.stamp
+    print("getting stamp")
+    print(pointstamped.stamp)
 #    mytime = rospy.Time().now()
     mytime = rospy.Time(10,20)
     pointstamped.stamp = mytime
-    print mytime
-    print "getting stamp"
+    print(mytime)
+    print("getting stamp")
     output = pointstamped.stamp
-    print output
-    print pointstamped.point
-    print transform_stamped.transform * pointstamped.point
+    print(output)
+    print(pointstamped.point)
+    print(transform_stamped.transform * pointstamped.point)
 
     pose_only = bullet.Transform(transform_stamped.transform)
-    print "destructing pose_only", pose_only.this    
+    print("destructing pose_only", pose_only.this    )
     pose_only = []
 
     
-    print "Creating copy"
+    print("Creating copy")
     po2_copy = tf.PoseStamped(po2)
-    print "po2_copy.pose", po2_copy.pose.this
-    print "po2.pose", po2.pose.this
+    print("po2_copy.pose", po2_copy.pose.this)
+    print("po2.pose", po2.pose.this)
 
-    print "Creating copy2"
+    print("Creating copy2")
     po2_copy2 = tf.PoseStamped(po2)
-    print "po2_copy2.pose", po2_copy2.pose.this
+    print("po2_copy2.pose", po2_copy2.pose.this)
 
 
-    print "destructing po2  po2.pose is", po2.pose.this
+    print("destructing po2  po2.pose is", po2.pose.this)
     po2 = []
 
 
-    print "destructing po2_copy po2_copy.pose is", po2_copy.pose.this
+    print("destructing po2_copy po2_copy.pose is", po2_copy.pose.this)
     po2_copy = []    
 
     
@@ -149,9 +151,9 @@ try:
     
 
 
-    print "done"
+    print("done")
 
 except ValueError, e:
-    print "Exception %s Improperly thrown: %s"%(type(e), e)
+    print("Exception %s Improperly thrown: %s"%(type(e), e))
 
 

--- a/tf/test/testPython.py
+++ b/tf/test/testPython.py
@@ -192,7 +192,7 @@ class TestPython(unittest.TestCase):
         try:
           tr.waitForTransform("PARENT", "THISFRAME", rospy.Time().from_sec(4.0), rospy.Duration(3.0))
           self.assertFalse("This should throw")
-        except tf.Exception, ex:
+        except tf.Exception as ex:
           print("successfully caught")
           pass 
         
@@ -204,7 +204,7 @@ class TestPython(unittest.TestCase):
         try:
           tr.waitForTransform("PARENT", "THISFRAME", rospy.Time().from_sec(4.0), rospy.Duration(3.0))
           self.assertFalse("This should throw")
-        except tf.Exception, ex:
+        except tf.Exception as ex:
           pass 
 
         m = geometry_msgs.msg.TransformStamped()
@@ -222,7 +222,7 @@ class TestPython(unittest.TestCase):
 
         try:
           tr.waitForTransform("PARENT", "THISFRAME", rospy.Time().from_sec(4.0), rospy.Duration(3.0))
-        except tf.Exception, ex:
+        except tf.Exception as ex:
           self.assertFalse("This should not throw")
 
 

--- a/tf/test/testPython.py
+++ b/tf/test/testPython.py
@@ -193,7 +193,7 @@ class TestPython(unittest.TestCase):
           tr.waitForTransform("PARENT", "THISFRAME", rospy.Time().from_sec(4.0), rospy.Duration(3.0))
           self.assertFalse("This should throw")
         except tf.Exception, ex:
-          print "successfully caught"
+          print("successfully caught")
           pass 
         
 

--- a/tf_conversions/src/tf_conversions/__init__.py
+++ b/tf_conversions/src/tf_conversions/__init__.py
@@ -25,4 +25,4 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from posemath import *
+from .posemath import *

--- a/tf_conversions/src/tf_conversions/posemath.py
+++ b/tf_conversions/src/tf_conversions/posemath.py
@@ -57,7 +57,7 @@ def fromTf(tf):
         ((668.5, 0.0, 0.0), (0.0, 0.0, 0.0, 1.0))
         >>> import tf_conversions.posemath as pm
         >>> p = pm.fromTf(t.lookupTransform('THISFRAME', 'CHILD', rospy.Time(0)))
-        >>> print pm.toMsg(p * p)
+        >>> print(pm.toMsg(p * p))
         position: 
           x: 1337.0
           y: 0.0


### PR DESCRIPTION
A modest step toward python 3 support in ROS.  Fixes all the problems detailed in the [wiki](http://wiki.ros.org/python_2_and_3_compatible_code) as well as the tf extension module.  Most are simply string replacements, but based on python 3 docs and [_roslz4module.c](https://github.com/ros/ros_comm/blob/indigo-devel/utilities/roslz4/src/_roslz4module.c), in pytf.cpp all module state is moved from global variables to a struct linked to each initialization.   This requires a bit of code shuffling and isn't strictly necessary.   I have another [version](https://github.com/pallegro/geometry/blob/indigo-devel/tf/src/pytf.cpp) which leaves things as they are.
Tested with python 2.7 and 3.4.  Note that tf/test/testPython.py has two failing test cases with or without these changes (getLatestCommonTime with no common ancestor returns time(0) rather than raising an exception).
