### PR TITLE
Larger default queue size in broadcaster

### DIFF
--- a/tf/src/tf/broadcaster.py
+++ b/tf/src/tf/broadcaster.py
@@ -41,8 +41,9 @@ class TransformBroadcaster:
     :class:`TransformBroadcaster` is a convenient way to send transformation updates on the ``"/tf"`` message topic.
     """
 
-    def __init__(self):
-        self.pub_tf = rospy.Publisher("/tf", tf.msg.tfMessage, queue_size=1)
+    def __init__(self, queue_size=100):
+        self.pub_tf = rospy.Publisher("/tf", tf.msg.tfMessage,
+                queue_size=queue_size)
 
     def sendTransform(self, translation, rotation, time, child, parent):
         """


### PR DESCRIPTION
With queue_size=1 when two transforms are sent in quick succession,
the second is often lost. The C++ code uses a default queue_size of
100, so switch to that default here as well. If that is not appropriate,
a queue_size constructor argument is provided.

Fixes #71 
