### PR TITLE
Install static lib and remove test and Python libs for Android

### DIFF
--- a/tf/CMakeLists.txt
+++ b/tf/CMakeLists.txt
@@ -46,7 +46,7 @@ add_executable(static_transform_publisher src/static_transform_publisher.cpp)
 target_link_libraries(static_transform_publisher ${PROJECT_NAME})
 
 # Tests
-if(CATKIN_ENABLE_TESTING)
+if(CATKIN_ENABLE_TESTING AND NOT ANDROID)
 
 find_package(rostest)
 
@@ -98,6 +98,7 @@ target_link_libraries(testBroadcaster ${PROJECT_NAME})
 endif()
 
 
+if(NOT ANDROID)
 #Python setup
 set(Python_ADDITIONAL_VERSIONS 2.7)
 find_package(PythonLibs REQUIRED)
@@ -135,8 +136,9 @@ set_target_properties(pytf_py PROPERTIES OUTPUT_NAME tf PREFIX "_" SUFFIX ".so"
 # add_pyunit(test/testPython.py) 
 # DOES PYUNIT WORK IN CATKIN?
 target_link_libraries(pytf_py ${Boost_LIBRARIES} ${catkin_LIBRARIES})
+endif()
 
-if(CATKIN_ENABLE_TESTING)
+if(CATKIN_ENABLE_TESTING AND NOT ANDROID)
 add_executable(tf_speed_test EXCLUDE_FROM_ALL test/speed_test.cpp)
 target_link_libraries(tf_speed_test ${PROJECT_NAME})
 endif()
@@ -146,11 +148,14 @@ install(DIRECTORY include/${PROJECT_NAME}/
   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})
 
 install(TARGETS ${PROJECT_NAME} tf_echo tf_empty_listener tf_change_notifier tf_monitor static_transform_publisher
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 
+if(NOT ANDROID)
 install(TARGETS pytf_py
   LIBRARY DESTINATION ${CMAKE_INSTALL_PREFIX}/${PYTHON_INSTALL_DIR}/tf)
+endif()
 
 # Install rosrun-able scripts
 install(PROGRAMS 


### PR DESCRIPTION
- In order to build tf for android we need to use static libraries.
- We don't have Python so I removed the pytf_py library when building for Android
- I've also had a lot of issues to make the tests work, so I disabled them for Android.
