### PR TITLE
update view_frames to use AllFramesAsDot(rospy.time.now())

### DIFF
--- a/tf/include/tf/tf.h
+++ b/tf/include/tf/tf.h
@@ -294,7 +294,7 @@ public:
   /** \brief A way to see what frames have been cached
    * Useful for debugging
    */
-  std::string allFramesAsDot() const;
+  std::string allFramesAsDot(double current_time = 0) const;
 
   /** \brief A way to get a std::vector of available frame ids */
   void getFrameStrings(std::vector<std::string>& ids) const;

--- a/tf/scripts/view_frames
+++ b/tf/scripts/view_frames
@@ -61,7 +61,7 @@ def listen(duration):
     print "Listening to /tf for %f seconds"%duration
     time.sleep(duration)
     print "Done Listening"
-    return tf_listener.allFramesAsDot()
+    return tf_listener.allFramesAsDot(rospy.Time.now())
     
 
 def poll(node_name):

--- a/tf/src/pytf.cpp
+++ b/tf/src/pytf.cpp
@@ -139,10 +139,14 @@ static PyObject *getTFPrefix(PyObject *self, PyObject *args)
   return PyString_FromString(t->getTFPrefix().c_str());
 }
 
-static PyObject *allFramesAsDot(PyObject *self, PyObject *args)
+static PyObject *allFramesAsDot(PyObject *self, PyObject *args, PyObject *kw)
 {
   tf::Transformer *t = ((transformer_t*)self)->t;
-  return PyString_FromString(t->allFramesAsDot().c_str());
+  static const char *keywords[] = { "time", NULL };
+  ros::Time time;
+  if (!PyArg_ParseTupleAndKeywords(args, kw, "|O&", (char**)keywords, rostime_converter, &time))
+    return NULL;
+  return PyString_FromString(t->allFramesAsDot(time.toSec()).c_str());
 }
 
 static PyObject *allFramesAsString(PyObject *self, PyObject *args)
@@ -445,7 +449,7 @@ static PyObject *getFrameStrings(PyObject *self, PyObject *args)
 
 static struct PyMethodDef transformer_methods[] =
 {
-  {"allFramesAsDot", allFramesAsDot, METH_VARARGS},
+  {"allFramesAsDot", (PyCFunction)allFramesAsDot, METH_KEYWORDS},
   {"allFramesAsString", allFramesAsString, METH_VARARGS},
   {"setTransform", setTransform, METH_VARARGS},
   {"canTransform", (PyCFunction)canTransform, METH_KEYWORDS},

--- a/tf/src/tf.cpp
+++ b/tf/src/tf.cpp
@@ -436,9 +436,9 @@ std::string Transformer::allFramesAsString() const
   return tf2_buffer_.allFramesAsString();
 }
 
-std::string Transformer::allFramesAsDot() const
+std::string Transformer::allFramesAsDot(double current_time) const
 {
-  return tf2_buffer_._allFramesAsDot();
+  return tf2_buffer_._allFramesAsDot(current_time);
 }
 
 


### PR DESCRIPTION
this is workaround for https://github.com/ros/geometry_experimental/pull/73, we need https://github.com/ros/geometry_experimental/pull/74 patch.
