### PR TITLE
Fixed Vector3 documentation

### DIFF
--- a/tf/conf.py
+++ b/tf/conf.py
@@ -199,7 +199,6 @@ latex_documents = [
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
     'http://docs.python.org/': None,
-    'http://opencv.willowgarage.com/documentation/': None,
-    'http://opencv.willowgarage.com/documentation/python/': None,
+    'http://docs.opencv.org/3.0-last-rst/': None,
     'http://docs.scipy.org/doc/numpy' : None
     }

--- a/tf/include/tf/LinearMath/Vector3.h
+++ b/tf/include/tf/LinearMath/Vector3.h
@@ -29,11 +29,13 @@ namespace tf{
 
 
 
-/**@brief Vector3 can be used to represent 3D points and vectors.
+/**
+ * @class Vector3
+ * @brief Vector3 can be used to represent 3D points and vectors.
  * It has an un-used w component to suit 16-byte alignment when Vector3 is stored in containers. This extra component can be used by derived classes (Quaternion?) or by user
  * Ideally, this class should be replaced by a platform optimized SIMD version that keeps the data in registers
  */
-ATTRIBUTE_ALIGNED16(class) Vector3
+class Vector3
 {
 public:
 
@@ -345,7 +347,7 @@ public:
 
 		TFSIMD_FORCE_INLINE	void	deSerializeDouble(const struct	Vector3DoubleData& dataIn);
 
-};
+} __attribute__ ((aligned(16)));
 
 /**@brief Return the sum of two vectors (Point symantics)*/
 TFSIMD_FORCE_INLINE Vector3 

--- a/tf_conversions/conf.py
+++ b/tf_conversions/conf.py
@@ -199,8 +199,7 @@ latex_documents = [
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
     'http://docs.python.org/': None,
-    'http://opencv.willowgarage.com/documentation/': None,
-    'http://opencv.willowgarage.com/documentation/python/': None,
+    'http://docs.opencv.org/3.0-last-rst/': None,
     'http://www.ros.org/doc/api/tf/html/python/' : None,
     'http://docs.scipy.org/doc/numpy' : None,
     'http://www.ros.org/doc/api/kdl/html/python/' : None


### PR DESCRIPTION
Fixed issue #42 by replacing the `ATTRIBUTE_ALIGNED16` macro in `Vector3` with its definition, `__attribute__ ((aligned(16)))`.

You can view the new docs with `rosdoc_lite tf`.

I also got rid of a broken `opencv.willowgarage.com` link that was slowing down documentation generation.
