### PR TITLE
Removed msg/serv installation from CMakelists

### DIFF
--- a/tf/CMakeLists.txt
+++ b/tf/CMakeLists.txt
@@ -161,15 +161,6 @@ install(PROGRAMS
   scripts/view_frames
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION} )
 
-# Need to install python msg and srv directories manually because genmsg
-# specifically avoids installing python message code if catkin_python_setup()
-# has been used.  See https://github.com/ros/genmsg/issues/10
-install(DIRECTORY ${CATKIN_DEVEL_PREFIX}/${PYTHON_INSTALL_DIR}/tf/msg
-  DESTINATION ${CMAKE_INSTALL_PREFIX}/${PYTHON_INSTALL_DIR}/tf)
-install(DIRECTORY ${CATKIN_DEVEL_PREFIX}/${PYTHON_INSTALL_DIR}/tf/srv
-  DESTINATION ${CMAKE_INSTALL_PREFIX}/${PYTHON_INSTALL_DIR}/tf)
-
-
 if(TARGET tests)
   add_dependencies(tests testBroadcaster testListener transform_listener_unittest test_message_filter )
 endif()


### PR DESCRIPTION
Issue #5. Removed auto-generated msg and serv installation from CMakeLists since it is now automatically installed by genmsg.
