### PR TITLE
Remove outdated manifest loading in python files

### DIFF
--- a/tf/conf.py
+++ b/tf/conf.py
@@ -11,8 +11,6 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import roslib
-roslib.load_manifest('tf')
 import sys, os
 
 # If extensions (or modules to document with autodoc) are in another directory,

--- a/tf/scripts/python_benchmark.py
+++ b/tf/scripts/python_benchmark.py
@@ -30,8 +30,6 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-import roslib
-roslib.load_manifest('tf')
 import rostest
 import rospy
 import numpy

--- a/tf/scripts/tf_remap
+++ b/tf/scripts/tf_remap
@@ -35,8 +35,6 @@
 
 ## remap a tf topic
 
-import roslib; roslib.load_manifest('tf')
-
 import rospy
 from tf.msg import tfMessage
 

--- a/tf/scripts/view_frames
+++ b/tf/scripts/view_frames
@@ -38,10 +38,6 @@
 
 from __future__ import with_statement
 
-PKG = 'tf' # this package name
-
-import roslib; roslib.load_manifest(PKG) 
-
 import sys, time
 import os
 import string

--- a/tf/src/tf/listener.py
+++ b/tf/src/tf/listener.py
@@ -25,10 +25,6 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-PKG = 'tf'
-import roslib
-roslib.load_manifest(PKG)
-
 import rospy
 import tf as TFX
 from tf import transformations

--- a/tf/test/method_test.py
+++ b/tf/test/method_test.py
@@ -1,5 +1,3 @@
-import roslib; roslib.load_manifest("tf")
-
 import rospy
 import tf
 import time

--- a/tf/test/python_debug_test.py
+++ b/tf/test/python_debug_test.py
@@ -25,8 +25,6 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-import roslib; roslib.load_manifest("tf")
-
 import rospy
 import tf
 import time

--- a/tf/test/test_datatype_conversion.py
+++ b/tf/test/test_datatype_conversion.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-import roslib; roslib.load_manifest('tf')
 
 import sys
 import unittest

--- a/tf_conversions/conf.py
+++ b/tf_conversions/conf.py
@@ -11,8 +11,6 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import roslib
-roslib.load_manifest('tf_conversions')
 import sys, os
 
 # If extensions (or modules to document with autodoc) are in another directory,

--- a/tf_conversions/test/posemath.py
+++ b/tf_conversions/test/posemath.py
@@ -1,5 +1,3 @@
-import roslib
-roslib.load_manifest('tf_conversions')
 import rostest
 import rospy
 import numpy


### PR DESCRIPTION
Resolves #104.

I removed all instances of `load_manifest` I could find, as well as the `roslib` imports.
