### PR TITLE
Add conversion functions for Eigen::Isometry3d.

### DIFF
--- a/eigen_conversions/include/eigen_conversions/eigen_kdl.h
+++ b/eigen_conversions/include/eigen_conversions/eigen_kdl.h
@@ -47,11 +47,17 @@ void quaternionKDLToEigen(const KDL::Rotation &k, Eigen::Quaterniond &e);
 /// Converts an Eigen quaternion into a KDL rotation
 void quaternionEigenToKDL(const Eigen::Quaterniond &e, KDL::Rotation &k);
 
-/// Converts a KDL frame into an Eigen transform
+/// Converts a KDL frame into an Eigen Affine3d
 void transformKDLToEigen(const KDL::Frame &k, Eigen::Affine3d &e);
 
-/// Converts an Eigen transform into a KDL frame
+/// Converts a KDL frame into an Eigen Isometry3d
+void transformKDLToEigen(const KDL::Frame &k, Eigen::Isometry3d &e);
+
+/// Converts an Eigen Affine3d into a KDL frame
 void transformEigenToKDL(const Eigen::Affine3d &e, KDL::Frame &k);
+
+/// Converts an Eigen Isometry3d into a KDL frame
+void transformEigenToKDL(const Eigen::Isometry3d &e, KDL::Frame &k);
 
 /// Converts a KDL twist into an Eigen matrix
 void twistKDLToEigen(const KDL::Twist &k, Eigen::Matrix<double, 6, 1> &e);

--- a/eigen_conversions/include/eigen_conversions/eigen_msg.h
+++ b/eigen_conversions/include/eigen_conversions/eigen_msg.h
@@ -54,11 +54,17 @@ void pointMsgToEigen(const geometry_msgs::Point &m, Eigen::Vector3d &e);
 /// Converts an Eigen Vector into a Point message
 void pointEigenToMsg(const Eigen::Vector3d &e, geometry_msgs::Point &m);
 
-/// Converts a Pose message into an Eigen Transform
+/// Converts a Pose message into an Eigen Affine3d
 void poseMsgToEigen(const geometry_msgs::Pose &m, Eigen::Affine3d &e);
 
-/// Converts an Eigen transform into a Pose message
+/// Converts a Pose message into an Eigen Isometry3d
+void poseMsgToEigen(const geometry_msgs::Pose &m, Eigen::Isometry3d &e);
+
+/// Converts an Eigen Affine3d into a Pose message
 void poseEigenToMsg(const Eigen::Affine3d &e, geometry_msgs::Pose &m);
+
+/// Converts an Eigen Isometry3d into a Pose message
+void poseEigenToMsg(const Eigen::Isometry3d &e, geometry_msgs::Pose &m);
 
 /// Converts a Quaternion message into an Eigen Quaternion
 void quaternionMsgToEigen(const geometry_msgs::Quaternion &m, Eigen::Quaterniond &e);
@@ -66,11 +72,17 @@ void quaternionMsgToEigen(const geometry_msgs::Quaternion &m, Eigen::Quaterniond
 /// Converts an Eigen Quaternion into a Quaternion message
 void quaternionEigenToMsg(const Eigen::Quaterniond &e, geometry_msgs::Quaternion &m);
 
-/// Converts a Transform message into an Eigen Transform
+/// Converts a Transform message into an Eigen Affine3d
 void transformMsgToEigen(const geometry_msgs::Transform &m, Eigen::Affine3d &e);
 
-/// Converts an Eigen transform into a Transform message
+/// Converts a Transform message into an Eigen Isometry3d
+void transformMsgToEigen(const geometry_msgs::Transform &m, Eigen::Isometry3d &e);
+
+/// Converts an Eigen Affine3d into a Transform message
 void transformEigenToMsg(const Eigen::Affine3d &e, geometry_msgs::Transform &m);
+
+/// Converts an Eigen Isometry3d into a Transform message
+void transformEigenToMsg(const Eigen::Isometry3d &e, geometry_msgs::Transform &m);
 
 /// Converts a Twist message into an Eigen matrix
 void twistMsgToEigen(const geometry_msgs::Twist &m, Eigen::Matrix<double,6,1> &e);

--- a/eigen_conversions/src/eigen_kdl.cpp
+++ b/eigen_conversions/src/eigen_kdl.cpp
@@ -47,29 +47,54 @@ void quaternionEigenToKDL(const Eigen::Quaterniond &e, KDL::Rotation &k)
   k = KDL::Rotation::Quaternion(e.x(), e.y(), e.z(), e.w());  
 }
 
+namespace {
+  template<typename T>
+  void transformKDLToEigenImpl(const KDL::Frame &k, T &e)
+  {
+    // translation
+    for (unsigned int i = 0; i < 3; ++i)
+      e(i, 3) = k.p[i];
+
+    // rotation matrix
+    for (unsigned int i = 0; i < 9; ++i)
+      e(i/3, i%3) = k.M.data[i];
+
+    // "identity" row
+    e(3,0) = 0.0;
+    e(3,1) = 0.0;
+    e(3,2) = 0.0;
+    e(3,3) = 1.0;
+  }
+
+  template<typename T>
+  void transformEigenToKDLImpl(const T &e, KDL::Frame &k)
+  {
+    for (unsigned int i = 0; i < 3; ++i)
+      k.p[i] = e(i, 3);
+    for (unsigned int i = 0; i < 9; ++i)
+      k.M.data[i] = e(i/3, i%3);
+  }
+
+}
+
 void transformKDLToEigen(const KDL::Frame &k, Eigen::Affine3d &e)
 {
-  // translation
-  for (unsigned int i = 0; i < 3; ++i)
-    e(i, 3) = k.p[i];                                                                                                             
+  transformKDLToEigenImpl(k, e);
+}
 
-  // rotation matrix
-  for (unsigned int i = 0; i < 9; ++i)
-    e(i/3, i%3) = k.M.data[i];
-
-  // "identity" row
-  e(3,0) = 0.0;
-  e(3,1) = 0.0;
-  e(3,2) = 0.0;
-  e(3,3) = 1.0;
+void transformKDLToEigen(const KDL::Frame &k, Eigen::Isometry3d &e)
+{
+  transformKDLToEigenImpl(k, e);
 }
 
 void transformEigenToKDL(const Eigen::Affine3d &e, KDL::Frame &k)
 {
-  for (unsigned int i = 0; i < 3; ++i)
-    k.p[i] = e(i, 3);                                                                                                             
-  for (unsigned int i = 0; i < 9; ++i)
-    k.M.data[i] = e(i/3, i%3);
+  transformEigenToKDLImpl(e, k);
+}
+
+void transformEigenToKDL(const Eigen::Isometry3d &e, KDL::Frame &k)
+{
+  transformEigenToKDLImpl(e, k);
 }
 
 void twistEigenToKDL(const Eigen::Matrix<double, 6, 1> &e, KDL::Twist &k)

--- a/eigen_conversions/src/eigen_msg.cpp
+++ b/eigen_conversions/src/eigen_msg.cpp
@@ -46,33 +46,88 @@ void pointEigenToMsg(const Eigen::Vector3d &e, geometry_msgs::Point &m)
   m.z = e(2);
 }
 
+namespace {
+  template<typename T>
+  void poseMsgToEigenImpl(const geometry_msgs::Pose &m, T &e)
+  {
+    e = Eigen::Translation3d(m.position.x,
+                             m.position.y,
+                             m.position.z) *
+      Eigen::Quaterniond(m.orientation.w,
+                         m.orientation.x,
+                         m.orientation.y,
+                         m.orientation.z);
+  }
+
+  template<typename T>
+  void poseEigenToMsgImpl(const T &e, geometry_msgs::Pose &m)
+  {
+    m.position.x = e.translation()[0];
+    m.position.y = e.translation()[1];
+    m.position.z = e.translation()[2];
+    Eigen::Quaterniond q = (Eigen::Quaterniond)e.linear();
+    m.orientation.x = q.x();
+    m.orientation.y = q.y();
+    m.orientation.z = q.z();
+    m.orientation.w = q.w();
+    if (m.orientation.w < 0) {
+      m.orientation.x *= -1;
+      m.orientation.y *= -1;
+      m.orientation.z *= -1;
+      m.orientation.w *= -1;
+    }
+  }
+
+  template<typename T>
+  void transformMsgToEigenImpl(const geometry_msgs::Transform &m, T &e)
+  {
+    e = Eigen::Translation3d(m.translation.x,
+                             m.translation.y,
+                             m.translation.z) *
+      Eigen::Quaterniond(m.rotation.w,
+                         m.rotation.x,
+                         m.rotation.y,
+                         m.rotation.z);
+  }
+
+  template<typename T>
+  void transformEigenToMsgImpl(const T &e, geometry_msgs::Transform &m)
+  {
+    m.translation.x = e.translation()[0];
+    m.translation.y = e.translation()[1];
+    m.translation.z = e.translation()[2];
+    Eigen::Quaterniond q = (Eigen::Quaterniond)e.linear();
+    m.rotation.x = q.x();
+    m.rotation.y = q.y();
+    m.rotation.z = q.z();
+    m.rotation.w = q.w();
+    if (m.rotation.w < 0) {
+      m.rotation.x *= -1;
+      m.rotation.y *= -1;
+      m.rotation.z *= -1;
+      m.rotation.w *= -1;
+    }
+  }
+}
+
 void poseMsgToEigen(const geometry_msgs::Pose &m, Eigen::Affine3d &e)
 {
-  e = Eigen::Translation3d(m.position.x,
-                           m.position.y,
-                           m.position.z) *
-    Eigen::Quaterniond(m.orientation.w,
-                       m.orientation.x,
-                       m.orientation.y,
-                       m.orientation.z);
+  poseMsgToEigenImpl(m, e);
+}
+
+void poseMsgToEigen(const geometry_msgs::Pose &m, Eigen::Isometry3d &e)
+{
+  poseMsgToEigenImpl(m, e);
 }
 
 void poseEigenToMsg(const Eigen::Affine3d &e, geometry_msgs::Pose &m)
 {
-  m.position.x = e.translation()[0];
-  m.position.y = e.translation()[1];
-  m.position.z = e.translation()[2];
-  Eigen::Quaterniond q = (Eigen::Quaterniond)e.linear();
-  m.orientation.x = q.x();
-  m.orientation.y = q.y();
-  m.orientation.z = q.z();
-  m.orientation.w = q.w();
-  if (m.orientation.w < 0) {
-    m.orientation.x *= -1;
-    m.orientation.y *= -1;
-    m.orientation.z *= -1;
-    m.orientation.w *= -1;
-  }
+  poseEigenToMsgImpl(e, m);
+}
+
+void poseEigenToMsg(const Eigen::Isometry3d &e, geometry_msgs::Pose &m)
+{
+  poseEigenToMsgImpl(e, m);
 }
 
 void quaternionMsgToEigen(const geometry_msgs::Quaternion &m, Eigen::Quaterniond &e)
@@ -89,32 +144,23 @@ void quaternionEigenToMsg(const Eigen::Quaterniond &e, geometry_msgs::Quaternion
 }
 
 void transformMsgToEigen(const geometry_msgs::Transform &m, Eigen::Affine3d &e)
-{ 
-  e = Eigen::Translation3d(m.translation.x,
-                           m.translation.y,
-                           m.translation.z) *
-    Eigen::Quaterniond(m.rotation.w,
-                       m.rotation.x,
-                       m.rotation.y,
-                       m.rotation.z);
+{
+  transformMsgToEigenImpl(m, e);
+}
+
+void transformMsgToEigen(const geometry_msgs::Transform &m, Eigen::Isometry3d &e)
+{
+  transformMsgToEigenImpl(m, e);
 }
 
 void transformEigenToMsg(const Eigen::Affine3d &e, geometry_msgs::Transform &m)
-{  
-  m.translation.x = e.translation()[0];
-  m.translation.y = e.translation()[1];
-  m.translation.z = e.translation()[2];
-  Eigen::Quaterniond q = (Eigen::Quaterniond)e.linear();
-  m.rotation.x = q.x();
-  m.rotation.y = q.y();
-  m.rotation.z = q.z();
-  m.rotation.w = q.w();
-  if (m.rotation.w < 0) {
-    m.rotation.x *= -1;
-    m.rotation.y *= -1;
-    m.rotation.z *= -1;
-    m.rotation.w *= -1;
-  }
+{
+  transformEigenToMsgImpl(e, m);
+}
+
+void transformEigenToMsg(const Eigen::Isometry3d &e, geometry_msgs::Transform &m)
+{
+  transformEigenToMsgImpl(e, m);
 }
 
 void vectorMsgToEigen(const geometry_msgs::Vector3 &m, Eigen::Vector3d &e)

--- a/tf_conversions/include/tf_conversions/tf_eigen.h
+++ b/tf_conversions/include/tf_conversions/tf_eigen.h
@@ -47,8 +47,14 @@ void matrixEigenToTF(const Eigen::Matrix3d &e, tf::Matrix3x3 &t);
 /// Converts a tf Pose into an Eigen Affine3d
 void poseTFToEigen(const tf::Pose &t, Eigen::Affine3d &e);
 
+/// Converts a tf Pose into an Eigen Isometry3d
+void poseTFToEigen(const tf::Pose &t, Eigen::Isometry3d &e);
+
 /// Converts an Eigen Affine3d into a tf Transform
 void poseEigenToTF(const Eigen::Affine3d &e, tf::Pose &t);
+
+/// Converts an Eigen Isometry3d into a tf Transform
+void poseEigenToTF(const Eigen::Isometry3d &e, tf::Pose &t);
 
 /// Converts a tf Quaternion into an Eigen Quaternion
 void quaternionTFToEigen(const tf::Quaternion &t, Eigen::Quaterniond &e);
@@ -59,8 +65,14 @@ void quaternionEigenToTF(const Eigen::Quaterniond &e, tf::Quaternion &t);
 /// Converts a tf Transform into an Eigen Affine3d
 void transformTFToEigen(const tf::Transform &t, Eigen::Affine3d &e);
 
+/// Converts a tf Transform into an Eigen Isometry3d
+void transformTFToEigen(const tf::Transform &t, Eigen::Isometry3d &e);
+
 /// Converts an Eigen Affine3d into a tf Transform
 void transformEigenToTF(const Eigen::Affine3d &e, tf::Transform &t);
+
+/// Converts an Eigen Isometry3d into a tf Transform
+void transformEigenToTF(const Eigen::Isometry3d &e, tf::Transform &t);
 
 /// Converts a tf Vector3 into an Eigen Vector3d
 void vectorTFToEigen(const tf::Vector3 &t, Eigen::Vector3d &e);

--- a/tf_conversions/src/tf_eigen.cpp
+++ b/tf_conversions/src/tf_eigen.cpp
@@ -52,7 +52,17 @@ namespace tf {
     transformTFToEigen(t, e);
   }
 
+  void poseTFToEigen(const tf::Pose &t, Eigen::Isometry3d &e)
+  {
+    transformTFToEigen(t, e);
+  }
+
   void poseEigenToTF(const Eigen::Affine3d &e, tf::Pose &t)
+  {
+    transformEigenToTF(e, t);
+  }
+
+  void poseEigenToTF(const Eigen::Isometry3d &e, tf::Pose &t)
   {
     transformEigenToTF(e, t);
   }
@@ -70,30 +80,54 @@ namespace tf {
     t[3] = e.w();
   }
 
+  namespace {
+    template<typename Transform>
+    void transformTFToEigenImpl(const tf::Transform &t, Transform & e)
+    {
+      for(int i=0; i<3; i++)
+      {
+        e.matrix()(i,3) = t.getOrigin()[i];
+        for(int j=0; j<3; j++)
+        {
+          e.matrix()(i,j) = t.getBasis()[i][j];
+        }
+      }
+      // Fill in identity in last row
+      for (int col = 0 ; col < 3; col ++)
+        e.matrix()(3, col) = 0;
+      e.matrix()(3,3) = 1;
+    }
+
+    template<typename T>
+    void transformEigenToTFImpl(const T &e, tf::Transform &t)
+    {
+      t.setOrigin(tf::Vector3( e.matrix()(0,3), e.matrix()(1,3), e.matrix()(2,3)));
+      t.setBasis(tf::Matrix3x3(e.matrix()(0,0), e.matrix()(0,1), e.matrix()(0,2),
+                               e.matrix()(1,0), e.matrix()(1,1), e.matrix()(1,2),
+                               e.matrix()(2,0), e.matrix()(2,1), e.matrix()(2,2)));
+    }
+  }
+
   void transformTFToEigen(const tf::Transform &t, Eigen::Affine3d &e)
   {
-    for(int i=0; i<3; i++)
-    {
-      e.matrix()(i,3) = t.getOrigin()[i];
-      for(int j=0; j<3; j++)
-      {
-        e.matrix()(i,j) = t.getBasis()[i][j];
-      }
-    }
-    // Fill in identity in last row
-    for (int col = 0 ; col < 3; col ++)
-      e.matrix()(3, col) = 0;
-    e.matrix()(3,3) = 1;
+    transformTFToEigenImpl(t, e);
+  };
+
+  void transformTFToEigen(const tf::Transform &t, Eigen::Isometry3d &e)
+  {
+    transformTFToEigenImpl(t, e);
   };
 
   void transformEigenToTF(const Eigen::Affine3d &e, tf::Transform &t)
   {
-    t.setOrigin(tf::Vector3( e.matrix()(0,3), e.matrix()(1,3), e.matrix()(2,3)));
-    t.setBasis(tf::Matrix3x3(e.matrix()(0,0), e.matrix()(0,1),e.matrix()(0,2),
-                             e.matrix()(1,0), e.matrix()(1,1),e.matrix()(1,2),
-                             e.matrix()(2,0), e.matrix()(2,1),e.matrix()(2,2)));
+    transformEigenToTFImpl(e, t);
   }
-  
+
+  void transformEigenToTF(const Eigen::Isometry3d &e, tf::Transform &t)
+  {
+    transformEigenToTFImpl(e, t);
+  }
+
   void vectorTFToEigen(const tf::Vector3& t, Eigen::Vector3d& e)
   {
     e(0) = t[0];

--- a/tf_conversions/test/test_eigen_tf.cpp
+++ b/tf_conversions/test/test_eigen_tf.cpp
@@ -85,43 +85,56 @@ TEST(TFEigenConversions, tf_eigen_transform)
   t.setOrigin(tf::Vector3(gen_rand(-10,10),gen_rand(-10,10),gen_rand(-10,10)));
   t.setRotation(tq);
 
-  Eigen::Affine3d k;
-  transformTFToEigen(t,k);
+  Eigen::Affine3d affine;
+  Eigen::Isometry3d isometry;
+  transformTFToEigen(t, affine);
+  transformTFToEigen(t, isometry);
 
   for(int i=0; i < 3; i++)
   {
-    ASSERT_NEAR(t.getOrigin()[i],k.matrix()(i,3),1e-6);
+    ASSERT_NEAR(t.getOrigin()[i],affine.matrix()(i,3),1e-6);
+    ASSERT_NEAR(t.getOrigin()[i],isometry.matrix()(i,3),1e-6);
     for(int j=0; j < 3; j++)
-    {      
-      ASSERT_NEAR(t.getBasis()[i][j],k.matrix()(i,j),1e-6);
+    {
+      ASSERT_NEAR(t.getBasis()[i][j],affine.matrix()(i,j),1e-6);
+      ASSERT_NEAR(t.getBasis()[i][j],isometry.matrix()(i,j),1e-6);
     }
   }
   for (int col = 0 ; col < 3; col ++)
-    ASSERT_NEAR(k.matrix()(3, col), 0, 1e-6);
-  ASSERT_NEAR(k.matrix()(3,3), 1, 1e-6);
-  
+  {
+    ASSERT_NEAR(affine.matrix()(3, col), 0, 1e-6);
+    ASSERT_NEAR(isometry.matrix()(3, col), 0, 1e-6);
+  }
+  ASSERT_NEAR(affine.matrix()(3,3), 1, 1e-6);
+  ASSERT_NEAR(isometry.matrix()(3,3), 1, 1e-6);
 }
 
 TEST(TFEigenConversions, eigen_tf_transform)
 {
-  tf::Transform t;
-  Eigen::Affine3d k;
+  tf::Transform t1;
+  tf::Transform t2;
+  Eigen::Affine3d affine;
+  Eigen::Isometry3d isometry;
   Eigen::Quaterniond kq;
   kq.coeffs()(0) = gen_rand(-1.0,1.0);
   kq.coeffs()(1) = gen_rand(-1.0,1.0);
   kq.coeffs()(2) = gen_rand(-1.0,1.0);
   kq.coeffs()(3) = gen_rand(-1.0,1.0);
   kq.normalize();
-  k.translate(Eigen::Vector3d(gen_rand(-10,10),gen_rand(-10,10),gen_rand(-10,10)));
-  k.rotate(kq);
+  isometry.translate(Eigen::Vector3d(gen_rand(-10,10),gen_rand(-10,10),gen_rand(-10,10)));
+  isometry.rotate(kq);
+  affine = isometry;
 
-  transformEigenToTF(k,t);
+  transformEigenToTF(affine,t1);
+  transformEigenToTF(isometry,t2);
   for(int i=0; i < 3; i++)
   {
-    ASSERT_NEAR(t.getOrigin()[i],k.matrix()(i,3),1e-6);
+    ASSERT_NEAR(t1.getOrigin()[i],affine.matrix()(i,3),1e-6);
+    ASSERT_NEAR(t2.getOrigin()[i],isometry.matrix()(i,3),1e-6);
     for(int j=0; j < 3; j++)
-    {      
-      ASSERT_NEAR(t.getBasis()[i][j],k.matrix()(i,j),1e-6);
+    {
+      ASSERT_NEAR(t1.getBasis()[i][j],affine.matrix()(i,j),1e-6);
+      ASSERT_NEAR(t2.getBasis()[i][j],isometry.matrix()(i,j),1e-6);
     }
   }
 }


### PR DESCRIPTION
I added overloads for Eigen::Isometry3d. It makes more sense than Affine3d since tf poses and transforms are isometries, and not affine transformations.

The functions are overloads, so code that is currently working is not affected.

To prevent code duplication the actual conversion is implemented as a function template in an anonymous namespace in the source file.

The unit tests are also updated to check both the affine and isometry versions.
