### PR TITLE
conversions: Add return-by-value wrappers.

### DIFF
--- a/eigen_conversions/include/eigen_conversions/eigen_kdl_by_value.h
+++ b/eigen_conversions/include/eigen_conversions/eigen_kdl_by_value.h
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2016, Delft Robotics
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * Author: Maarten de Vries
+ */
+
+#ifndef EIGEN_KDL_CONVERSIONS_BY_VALUE_H
+#define EIGEN_KDL_CONVERSIONS_BY_VALUE_H
+
+#include "eigen_kdl.h"
+
+namespace tf {
+
+/// Converts a KDL rotation into an Eigen quaternion
+Eigen::Quaterniond quaternionKDLToEigen(const KDL::Rotation &in)
+{
+  Eigen::Quaterniond result;
+  quaternionKDLToEigen(in, result);
+  return result;
+}
+
+/// Converts an Eigen quaternion into a KDL rotation
+KDL::Rotation quaternionEigenToKDL(const Eigen::Quaterniond &in)
+{
+  KDL::Rotation result;
+  quaternionEigenToKDL(in, result);
+  return result;
+}
+
+/// Converts a KDL frame into an Eigen Isometry3d
+Eigen::Isometry3d transformKDLToEigen(const KDL::Frame &in)
+{
+  Eigen::Isometry3d result;
+  transformKDLToEigen(in, result);
+  return result;
+}
+
+/// Converts an Eigen Affine3d into a KDL frame
+KDL::Frame transformEigenToKDL(const Eigen::Affine3d &in)
+{
+  KDL::Frame result;
+  transformEigenToKDL(in, result);
+  return result;
+}
+
+/// Converts an Eigen Isometry3d into a KDL frame
+KDL::Frame transformEigenToKDL(const Eigen::Isometry3d &in)
+{
+  KDL::Frame result;
+  transformEigenToKDL(in, result);
+  return result;
+}
+
+/// Converts a KDL twist into an Eigen matrix
+Eigen::Matrix<double, 6, 1> twistKDLToEigen(const KDL::Twist &in)
+{
+  Eigen::Matrix<double, 6, 1> result;
+  twistKDLToEigen(in, result);
+  return result;
+}
+
+/// Converts an Eigen matrix into a KDL Twist
+KDL::Twist twistEigenToKDL(const Eigen::Matrix<double, 6, 1> &in)
+{
+  KDL::Twist result;
+  twistEigenToKDL(in, result);
+  return result;
+}
+
+/// Converts a KDL vector into an Eigen matrix
+Eigen::Matrix<double, 3, 1> vectorKDLToEigen(const KDL::Vector &in)
+{
+  Eigen::Matrix<double, 3, 1> result;
+  vectorKDLToEigen(in, result);
+  return result;
+}
+
+/// Converts an Eigen matrix into a KDL vector
+KDL::Vector vectorEigenToKDL(const Eigen::Matrix<double, 3, 1> &in)
+{
+  KDL::Vector result;
+  vectorEigenToKDL(in, result);
+  return result;
+}
+
+/// Converts a KDL wrench into an Eigen matrix
+Eigen::Matrix<double, 6, 1> wrenchKDLToEigen(const KDL::Wrench &in)
+{
+  Eigen::Matrix<double, 6, 1> result;
+  wrenchKDLToEigen(in, result);
+  return result;
+}
+
+/// Converts an Eigen matrix into a KDL wrench
+KDL::Wrench wrenchEigenToKDL(const Eigen::Matrix<double, 6, 1> &in)
+{
+  KDL::Wrench result;
+  wrenchEigenToKDL(in, result);
+  return result;
+}
+
+
+} // namespace
+
+#endif

--- a/eigen_conversions/include/eigen_conversions/eigen_msg_by_value.h
+++ b/eigen_conversions/include/eigen_conversions/eigen_msg_by_value.h
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2016, Delft Robotics
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * Author: Maarten de Vries
+ */
+
+#ifndef EIGEN_MSG_CONVERSIONS_BY_VALUE_H
+#define EIGEN_MSG_CONVERSIONS_BY_VALUE_H
+
+#include "eigen_msg.h"
+
+namespace tf {
+
+/// Converts a Point message into an Eigen Vector
+Eigen::Vector3d pointMsgToEigen(const geometry_msgs::Point &in)
+{
+  Eigen::Vector3d result;
+  pointMsgToEigen(in, result);
+  return result;
+}
+
+/// Converts an Eigen Vector into a Point message
+geometry_msgs::Point pointEigenToMsg(const Eigen::Vector3d &in)
+{
+  geometry_msgs::Point result;
+  pointEigenToMsg(in, result);
+  return result;
+}
+
+/// Converts a Pose message into an Eigen Isometry3d
+Eigen::Isometry3d poseMsgToEigen(const geometry_msgs::Pose &in)
+{
+  Eigen::Isometry3d result;
+  poseMsgToEigen(in, result);
+  return result;
+}
+
+/// Converts an Eigen Affine3d into a Pose message
+geometry_msgs::Pose poseEigenToMsg(const Eigen::Affine3d &in)
+{
+  geometry_msgs::Pose result;
+  poseEigenToMsg(in, result);
+  return result;
+}
+
+/// Converts an Eigen Isometry3d into a Pose message
+geometry_msgs::Pose poseEigenToMsg(const Eigen::Isometry3d &in)
+{
+  geometry_msgs::Pose result;
+  poseEigenToMsg(in, result);
+  return result;
+}
+
+/// Converts a Quaternion message into an Eigen Quaternion
+Eigen::Quaterniond quaternionMsgToEigen(const geometry_msgs::Quaternion &in)
+{
+  Eigen::Quaterniond result;
+  quaternionMsgToEigen(in, result);
+  return result;
+}
+
+/// Converts an Eigen Quaternion into a Quaternion message
+geometry_msgs::Quaternion quaternionEigenToMsg(const Eigen::Quaterniond &in)
+{
+  geometry_msgs::Quaternion result;
+  quaternionEigenToMsg(in, result);
+  return result;
+}
+
+/// Converts a Transform message into an Eigen Isometry3d
+Eigen::Isometry3d transformMsgToEigen(const geometry_msgs::Transform &in)
+{
+  Eigen::Isometry3d result;
+  transformMsgToEigen(in, result);
+  return result;
+}
+
+/// Converts an Eigen Affine3d into a Transform message
+geometry_msgs::Transform transformEigenToMsg(const Eigen::Affine3d &in)
+{
+  geometry_msgs::Transform result;
+  transformEigenToMsg(in, result);
+  return result;
+}
+
+/// Converts an Eigen Isometry3d into a Transform message
+geometry_msgs::Transform transformEigenToMsg(const Eigen::Isometry3d &in)
+{
+  geometry_msgs::Transform result;
+  transformEigenToMsg(in, result);
+  return result;
+}
+
+/// Converts a Twist message into an Eigen matrix
+Eigen::Matrix<double,6,1> twistMsgToEigen(const geometry_msgs::Twist &in)
+{
+  Eigen::Matrix<double,6,1> result;
+  twistMsgToEigen(in, result);
+  return result;
+}
+
+/// Converts an Eigen matrix into a Twist message
+geometry_msgs::Twist twistEigenToMsg(const Eigen::Matrix<double,6,1> &in)
+{
+  geometry_msgs::Twist result;
+  twistEigenToMsg(in, result);
+  return result;
+}
+
+/// Converts a Vector message into an Eigen Vector
+Eigen::Vector3d vectorMsgToEigen(const geometry_msgs::Vector3 &in)
+{
+  Eigen::Vector3d result;
+  vectorMsgToEigen(in, result);
+  return result;
+}
+
+/// Converts an Eigen Vector into a Vector message
+geometry_msgs::Vector3 vectorEigenToMsg(const Eigen::Vector3d &in)
+{
+  geometry_msgs::Vector3 result;
+  vectorEigenToMsg(in, result);
+  return result;
+}
+
+/// Converts a Wrench message into an Eigen matrix
+Eigen::Matrix<double,6,1> wrenchMsgToEigen(const geometry_msgs::Wrench &in)
+{
+  Eigen::Matrix<double,6,1> result;
+  wrenchMsgToEigen(in, result);
+  return result;
+}
+
+/// Converts an Eigen matrix into a Wrench message
+geometry_msgs::Wrench wrenchEigenToMsg(const Eigen::Matrix<double,6,1> &in)
+{
+  geometry_msgs::Wrench result;
+  wrenchEigenToMsg(in, result);
+  return result;
+}
+
+/// Converts an Eigen matrix into a Float64MultiArray message
+template <class Derived>
+std_msgs::Float64MultiArray matrixEigenToMsg(const Eigen::MatrixBase<Derived> &in)
+{
+  std_msgs::Float64MultiArray result;
+  matrixEigenToMsg<Derived>(in, result);
+  return result;
+}
+
+} // namespace
+
+#endif

--- a/kdl_conversions/include/kdl_conversions/kdl_msg_by_value.h
+++ b/kdl_conversions/include/kdl_conversions/kdl_msg_by_value.h
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2016, Delft Robotics
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * Author: Maarten de Vries
+ */
+
+#ifndef CONVERSIONS_KDL_MSG_BY_VALUE_H
+#define CONVERSIONS_KDL_MSG_BY_VALUE_H
+
+#include "kdl_msg.h"
+
+
+namespace tf {
+
+/// Converts a geometry_msgs Point into a KDL Vector
+KDL::Vector pointMsgToKDL(const geometry_msgs::Point &in)
+{
+  KDL::Vector result;
+  pointMsgToKDL(in, result);
+  return result;
+}
+
+/// Converts a KDL Vector into a geometry_msgs Vector3
+geometry_msgs::Point pointKDLToMsg(const KDL::Vector &in)
+{
+  geometry_msgs::Point result;
+  pointKDLToMsg(in, result);
+  return result;
+}
+
+/// Converts a Pose message into a KDL Frame
+KDL::Frame poseMsgToKDL(const geometry_msgs::Pose &in)
+{
+  KDL::Frame result;
+  poseMsgToKDL(in, result);
+  return result;
+}
+
+/// Converts a KDL Frame into a Pose message
+geometry_msgs::Pose poseKDLToMsg(const KDL::Frame &in)
+{
+  geometry_msgs::Pose result;
+  poseKDLToMsg(in, result);
+  return result;
+}
+
+/// Converts a quaternion message into a KDL Rotation
+KDL::Rotation quaternionMsgToKDL(const geometry_msgs::Quaternion &in)
+{
+  KDL::Rotation result;
+  quaternionMsgToKDL(in, result);
+  return result;
+}
+
+/// Converts a KDL Rotation into a message quaternion
+geometry_msgs::Quaternion quaternionKDLToMsg(const KDL::Rotation &in)
+{
+  geometry_msgs::Quaternion result;
+  quaternionKDLToMsg(in, result);
+  return result;
+}
+
+/// Converts a Transform message into a KDL Frame
+KDL::Frame transformMsgToKDL(const geometry_msgs::Transform &in)
+{
+  KDL::Frame result;
+  transformMsgToKDL(in, result);
+  return result;
+}
+
+/// Converts a KDL Frame into a Transform message
+geometry_msgs::Transform transformKDLToMsg(const KDL::Frame &in)
+{
+  geometry_msgs::Transform result;
+  transformKDLToMsg(in, result);
+  return result;
+}
+
+/// Converts a Twist message into a KDL Twist
+KDL::Twist twistMsgToKDL(const geometry_msgs::Twist &in)
+{
+  KDL::Twist result;
+  twistMsgToKDL(in, result);
+  return result;
+}
+
+/// Converts a KDL Twist into a Twist message
+geometry_msgs::Twist twistKDLToMsg(const KDL::Twist &in)
+{
+  geometry_msgs::Twist result;
+  twistKDLToMsg(in, result);
+  return result;
+}
+
+/// Converts a Vector3 message into a KDL Vector
+KDL::Vector vectorMsgToKDL(const geometry_msgs::Vector3 &in)
+{
+  KDL::Vector result;
+  vectorMsgToKDL(in, result);
+  return result;
+}
+
+/// Converts a KDL Vector into a Vector3 message
+geometry_msgs::Vector3 vectorKDLToMsg(const KDL::Vector &in)
+{
+  geometry_msgs::Vector3 result;
+  vectorKDLToMsg(in, result);
+  return result;
+}
+
+/// Converts a Wrench message into a KDL Wrench
+KDL::Wrench wrenchMsgToKDL(const geometry_msgs::Wrench &in)
+{
+  KDL::Wrench result;
+  wrenchMsgToKDL(in, result);
+  return result;
+}
+
+/// Converts a KDL Wrench into a Wrench message
+geometry_msgs::Wrench wrenchKDLToMsg(const KDL::Wrench &in)
+{
+  geometry_msgs::Wrench result;
+  wrenchKDLToMsg(in, result);
+  return result;
+}
+
+
+
+}
+
+
+#endif
+
+
+

--- a/tf_conversions/include/tf_conversions/tf_eigen_by_value.hpp
+++ b/tf_conversions/include/tf_conversions/tf_eigen_by_value.hpp
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2016, Delft Robotics.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// Author: Maarten de Vries, Ronald Ensing
+
+#ifndef CONVERSIONS_TF_EIGEN_BY_VALUE_H
+#define CONVERSIONS_TF_EIGEN_BY_VALUE_H
+
+#include "tf/transform_datatypes.h"
+#include "tf_eigen.h"
+
+namespace tf {
+
+/// Converts a tf Matrix3x3 into an Eigen Quaternion
+Eigen::Matrix3d matrixTFToEigen(const tf::Matrix3x3 &in) {
+    Eigen::Matrix3d result;
+    matrixTFToEigen(in, result);
+    return result;
+}
+
+/// Converts an Eigen Quaternion into a tf Matrix3x3
+tf::Matrix3x3 matrixEigenToTF(const Eigen::Matrix3d &in) {
+
+    tf::Matrix3x3 result;
+    matrixEigenToTF(in, result);
+    return result;
+}
+
+/// Converts a tf Pose into an Eigen Isometry3d
+Eigen::Isometry3d poseTFToEigen(const tf::Pose &in) {
+
+    Eigen::Isometry3d result;
+    poseTFToEigen(in, result);
+    return result;
+}
+
+/// Converts an Eigen Affine3d into a tf Transform
+tf::Pose poseEigenToTF(const Eigen::Affine3d &in) {
+
+    tf::Pose result;
+    poseEigenToTF(in, result);
+    return result;
+}
+
+/// Converts an Eigen Isometry3d into a tf Transform
+tf::Pose poseEigenToTF(const Eigen::Isometry3d &in) {
+
+    tf::Pose result;
+    poseEigenToTF(in, result);
+    return result;
+}
+
+/// Converts a tf Quaternion into an Eigen Quaternion
+Eigen::Quaterniond quaternionTFToEigen(const tf::Quaternion &in) {
+    Eigen::Quaterniond result;
+    quaternionTFToEigen(in, result);
+    return result;
+}
+
+/// Converts an Eigen Quaternion into a tf Quaternion
+tf::Quaternion quaternionEigenToTF(const Eigen::Quaterniond &in) {
+    tf::Quaternion result;
+    quaternionEigenToTF(in, result);
+    return result;
+}
+
+/// Converts a tf Transform into an Eigen Isometry3d
+Eigen::Isometry3d transformTFToEigen(const tf::Transform &in) {
+
+    Eigen::Isometry3d result;
+    transformTFToEigen(in, result);
+    return result;
+}
+
+/// Converts an Eigen Affine3d into a tf Transform
+tf::Transform transformEigenToTF(const Eigen::Affine3d &in) {
+
+    tf::Transform result;
+    transformEigenToTF(in, result);
+    return result;
+}
+
+/// Converts an Eigen Isometry3d into a tf Transform
+tf::Transform transformEigenToTF(const Eigen::Isometry3d &in) {
+
+    tf::Transform result;
+    transformEigenToTF(in, result);
+    return result;
+}
+
+/// Converts a tf Vector3 into an Eigen Vector3d
+Eigen::Vector3d vectorTFToEigen(const tf::Vector3 &in) {
+    Eigen::Vector3d result;
+    vectorTFToEigen(in, result);
+    return result;
+}
+
+/// Converts an Eigen Vector3d into a tf Vector3
+tf::Vector3 vectorEigenToTF(const Eigen::Vector3d &in) {
+    tf::Vector3 result;
+    vectorEigenToTF(in, result);
+    return result;
+}
+
+} // namespace tf
+
+#endif


### PR DESCRIPTION
This pull request adds wrappers for the existing conversion functions that take only one argument and return the result by value. Right now they have the same names as the original functions (but see below). They are defined in a separate header.

Currently compiling code should not be affected even if some other header pulls in the by-value conversions since these functions have a different signature from the originals.

In my opinion the resulting code is much easier to read:

```
Eigen::Vector3d vector = vectorKDLtoEigen(kdl_vector);
```

VS

```
Eigen::Vector3d vector;
vectorKDLtoEigen(kdl_vector, vector);
```

The first snippet shows in a single look that `vector` is being set while for the second snippet you need to really read what the code says.

Additionally it allows passing the converted values directly to functions and initializer lists:

```
doSomething(vectorKDLtoEigen(position));

class Foo : public Bar {
public:
    // Can't even make a local variable here as workaround, need a return-by-value conversion function.
    Foo(Eigen::Vector3d const & position) : Bar(vectorEigenToKDL(position) {}
}
```
#### Affine3d

I didn't add a by-value conversion to `Eigen::Affine3d` because you can't overload on return type, and `Isometry3d` is implicitly convertible to `Affine3d`. So there is no need for a conversion by-value to `Affine3d` anyway.
#### Naming

I'm not sure on the naming of the functions yet. For conversion functions you don't really need the name to state what goes in, only what comes out. So I was thinking about names like

```
Eigen::Vector3d toEigenVector3d(const KDL::Vector &);
Eigen::Vector3d toEigenVector3d(const geometry_msgs::Point &);
Eigen::Vector3d toEigenVector3d(const geometry_msgs::Vector3 &);

KDL::Vector3 toKDLVector(const Eigen::Vector3d &);
geometry_msgs::Point toMsgPoint(const Eigen::Vector3d &);
geometry_msgs::Vector3 toMsgVector3(const Eigen::Vector3d &);
```

Converting twist and wrench values are both converted to a 6 dimensional vector in Eigen though, so would those get the same name then?

Thoughts on naming the functions are welcome.
