### PR TITLE
Change version regex for graphviz in view_frames

### DIFF
--- a/tf/scripts/view_frames
+++ b/tf/scripts/view_frames
@@ -91,7 +91,7 @@ def generate(dot_graph):
             print "Warning: Could not execute `dot -V`.  Is graphviz installed?"
             sys.exit(-1)
         v = distutils.version.StrictVersion('2.16')
-        r = re.compile(".*version ([^ ]*).*")
+        r = re.compile(".*version (\d+\.?\d*)")
         print vstr
         m = r.search(vstr)
         if not m or not m.group(1):


### PR DESCRIPTION
The previous version extraction regex would extract an arbitrary number of digit groups from the graphviz version string. If the version string had more than 3 digit groups, distutils.version.StrictVersion would fail. This fixes the problem by only extracting the first 2 digit groups of the version string.
(See #114)
