### PR TITLE
Fix warning for null conversion.

### DIFF
--- a/tf/src/pytf.cpp
+++ b/tf/src/pytf.cpp
@@ -467,12 +467,12 @@ static struct PyMethodDef transformer_methods[] =
   {"lookupTwistFull", lookupTwistFull, METH_VARARGS},
   {"setUsingDedicatedThread", (PyCFunction)setUsingDedicatedThread, METH_VARARGS},
   {"getTFPrefix", (PyCFunction)getTFPrefix, METH_VARARGS},
-  {NULL,          NULL}
+  {NULL, NULL}
 };
 
 static PyMethodDef module_methods[] = {
   // {"Transformer", mkTransformer, METH_VARARGS},
-  {NULL, NULL, NULL},
+  {NULL, NULL}
 };
 
 extern "C" void init_tf()


### PR DESCRIPTION
Error is `tf/src/pytf.cpp:476:1: warning: converting to non-pointer type 'int' from NULL [-Wconversion-null]`
