### PR TITLE
[doc] Add migration notice in manifest.

### DIFF
--- a/geometry/package.xml
+++ b/geometry/package.xml
@@ -1,7 +1,11 @@
 <package>
   <name>geometry</name>
   <version>1.11.8</version>
-  <description>Geometry Library</description>
+  <description><p>A metapackage for geometry library suite.</p>
+    <p><b>Migration</b>: Since ROS Hydro, tf has been "deprecated" in favor of <a href = "http://wiki.ros.org/tf2">tf2</a>. tf2 is an iteration on tf providing generally the same feature set more efficiently. As well as adding a few new features.<br/>
+    As tf2 is a major change the tf API has been maintained in its current form. Since tf2 has a superset of the tf features with a subset of the dependencies the tf implementation has been removed and replaced with calls to tf2 under the hood. This will mean that all users will be compatible with tf2. It is recommended for new work to use tf2 directly as it has a cleaner interface. However tf will continue to be supported for through at least J Turtle.
+    </p>
+  </description>
   <maintainer email="tfoote@osrfoundation.org">Tully Foote</maintainer>
   <license>BSD</license>
   

--- a/tf/package.xml
+++ b/tf/package.xml
@@ -9,6 +9,8 @@ frames in a tree structure buffered in time, and lets the user
 transform points, vectors, etc between any two coordinate frames at
 any desired point in time.
 
+    <p><b>Migration</b>: Since ROS Hydro, tf has been "deprecated" in favor of <a href = "http://wiki.ros.org/tf2">tf2</a>. tf2 is an iteration on tf providing generally the same feature set more efficiently. As well as adding a few new features.<br/>
+    As tf2 is a major change the tf API has been maintained in its current form. Since tf2 has a superset of the tf features with a subset of the dependencies the tf implementation has been removed and replaced with calls to tf2 under the hood. This will mean that all users will be compatible with tf2. It is recommended for new work to use tf2 directly as it has a cleaner interface. However tf will continue to be supported for through at least J Turtle.
   </description>
   <author>Tully Foote</author>
   <author>Eitan Marder-Eppstein</author>

--- a/tf/package.xml
+++ b/tf/package.xml
@@ -11,6 +11,7 @@ any desired point in time.
 
     <p><b>Migration</b>: Since ROS Hydro, tf has been "deprecated" in favor of <a href = "http://wiki.ros.org/tf2">tf2</a>. tf2 is an iteration on tf providing generally the same feature set more efficiently. As well as adding a few new features.<br/>
     As tf2 is a major change the tf API has been maintained in its current form. Since tf2 has a superset of the tf features with a subset of the dependencies the tf implementation has been removed and replaced with calls to tf2 under the hood. This will mean that all users will be compatible with tf2. It is recommended for new work to use tf2 directly as it has a cleaner interface. However tf will continue to be supported for through at least J Turtle.
+    </p>
   </description>
   <author>Tully Foote</author>
   <author>Eitan Marder-Eppstein</author>


### PR DESCRIPTION
Although it was noted in [Hydro migration note](http://wiki.ros.org/hydro/Migration#tf2.2BAC8-Migration.tf_and_tf2) that tf is "deprecated" and `tf2` is encouraged for newer development, in any `tf` documentation I don't see such an info AFAIK.
