### PR TITLE
Commented code caused error in documentation

### DIFF
--- a/tf/include/tf/transform_listener.h
+++ b/tf/include/tf/transform_listener.h
@@ -103,7 +103,7 @@ public:
    * This can throw all that lookupTransform can throw as well as tf::InvalidTransform */
   void transformPose(const std::string& target_frame, const geometry_msgs::PoseStamped& stamped_in, geometry_msgs::PoseStamped& stamped_out) const;
 
-  /** \brief Transform a Stamped Twist Message into the target frame 
+  /* \brief Transform a Stamped Twist Message into the target frame 
    * This can throw all that lookupTransform can throw as well as tf::InvalidTransform */
   // http://www.ros.org/wiki/tf/Reviews/2010-03-12_API_Review
   //  void transformTwist(const std::string& target_frame, const geometry_msgs::TwistStamped& stamped_in, geometry_msgs::TwistStamped& stamped_out) const;


### PR DESCRIPTION
See http://docs.ros.org/api/tf/html/c++/classtf_1_1TransformListener.html

The description for transformQuaternion() erroneously mentions Twist because of the commented code above the function definition. I believe this change to the format will avoid that.