### PR TITLE
Make python scripts Python3 compatible.

### DIFF
--- a/tf/scripts/bullet_migration_sed.py
+++ b/tf/scripts/bullet_migration_sed.py
@@ -82,9 +82,9 @@ namespaced_rules = [
 
 for rule in rules + unnamespaced_rules: #change me if using files with namespace tf set
     full_cmd = cmd%locals()
-    print ("Running %s"%full_cmd)
+    print("Running {}".format(full_cmd))
     ret_code = subprocess.call(full_cmd, shell=True)
     if ret_code == 0:
-        print ("success")
+        print("success")
     else:
-        print ("failure")
+        print("failure")

--- a/tf/scripts/bullet_migration_sed.py
+++ b/tf/scripts/bullet_migration_sed.py
@@ -40,6 +40,8 @@
 # If they are change the line below with the for loop to use the
 # namespaced_rules
 
+from __future__ import print_function
+
 import subprocess
 
 

--- a/tf/scripts/python_benchmark.py
+++ b/tf/scripts/python_benchmark.py
@@ -30,13 +30,19 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import print_function
+
 import rostest
 import rospy
 import numpy
 import unittest
 import sys
 import time
-import StringIO
+try:
+    from cStringIO import StringIO
+except ImportError:
+    from io import StringIO
+
 
 import tf.transformations
 import geometry_msgs.msg
@@ -59,7 +65,7 @@ def mkm():
 tm = tfMessage([mkm() for i in range(20)])
 
 def deserel_to_string(o):
-    s = StringIO.StringIO()
+    s = StringIO()
     o.serialize(s)
     return s.getvalue()
 
@@ -70,7 +76,7 @@ class Timer:
         self.func = func
     def mean(self, iterations = 1000000):
         started = time.time()
-        for i in xrange(iterations):
+        for i in range(iterations):
             self.func()
         took = time.time() - started
         return took / iterations
@@ -81,28 +87,28 @@ for t in [tf.msg.tfMessage, tf.cMsg.tfMessage]:
     m2 = t()
     m2.deserialize(mstr)
     for m in m2.transforms:
-        print type(m), sys.getrefcount(m)
+        print(type(m), sys.getrefcount(m))
     assert deserel_to_string(m2) == mstr, "deserel screwed up for type %s" % repr(t)
 
     m2 = t()
-    print "deserialize only ", 1e6 * Timer(lambda: m2.deserialize(mstr)).mean(), "us each"
+    print("deserialize only ", 1e6 * Timer(lambda: m2.deserialize(mstr)).mean(), "us each")
 
 sys.exit(0)
 
 started = time.time()
-for i in xrange(iterations):
+for i in range(iterations):
     for m in tm.transforms:
         t.setTransform(m)
 took = time.time() - started
-print "setTransform only", iterations, "took", took, "%f us each" % (1e6 * took / iterations)
+print("setTransform only", iterations, "took", took, "%f us each" % (1e6 * took / iterations))
 
 started = time.time()
-for i in xrange(iterations):
+for i in range(iterations):
     m2 = tfMessage()
     m2.deserialize(mstr)
     for m in m2.transforms:
         t.setTransform(m)
 took = time.time() - started
-print "deserialize+setTransform ", iterations, "took", took, "%f us each" % (1e6 * took / iterations)
+print("deserialize+setTransform ", iterations, "took", took, "%f us each" % (1e6 * took / iterations))
 
 from tf import TransformListener

--- a/tf/scripts/python_benchmark.py
+++ b/tf/scripts/python_benchmark.py
@@ -91,7 +91,7 @@ for t in [tf.msg.tfMessage, tf.cMsg.tfMessage]:
     assert deserel_to_string(m2) == mstr, "deserel screwed up for type %s" % repr(t)
 
     m2 = t()
-    print("deserialize only ", 1e6 * Timer(lambda: m2.deserialize(mstr)).mean(), "us each")
+    print("deserialize only {} us each".format(1e6 * Timer(lambda: m2.deserialize(mstr)).mean())
 
 sys.exit(0)
 
@@ -100,7 +100,7 @@ for i in range(iterations):
     for m in tm.transforms:
         t.setTransform(m)
 took = time.time() - started
-print("setTransform only", iterations, "took", took, "%f us each" % (1e6 * took / iterations))
+print("setTransform only {} took {} us each".format(iterations, took, (1e6 * took / iterations)))
 
 started = time.time()
 for i in range(iterations):
@@ -109,6 +109,6 @@ for i in range(iterations):
     for m in m2.transforms:
         t.setTransform(m)
 took = time.time() - started
-print("deserialize+setTransform ", iterations, "took", took, "%f us each" % (1e6 * took / iterations))
+print("deserialize+setTransform {} took {} us each".format(iterations, took, (1e6 * took / iterations)))
 
 from tf import TransformListener

--- a/tf/scripts/tf_remap
+++ b/tf/scripts/tf_remap
@@ -45,7 +45,7 @@ class TfRemapper:
         self.pub = rospy.Publisher('/tf', tfMessage, queue_size=1)
         mappings = rospy.get_param('~mappings', [])
         self.mappings = {}
-        
+
         for i in mappings:
             if "old" in i and "new" in i:
                 self.mappings[i["old"]] = i["new"]
@@ -59,14 +59,13 @@ class TfRemapper:
                 transform.header.frame_id = self.mappings[transform.header.frame_id]
             if transform.child_frame_id  in self.mappings:
                 transform.child_frame_id = self.mappings[transform.child_frame_id]
-                
+
         self.pub.publish(tf_msg)
 
 def remap_tf():
-    
     pub.publish(Empty())
 
-        
+
 if __name__ == '__main__':
     rospy.init_node('tf_remapper')
     tfr = TfRemapper()

--- a/tf/scripts/tf_remap
+++ b/tf/scripts/tf_remap
@@ -35,6 +35,8 @@
 
 ## remap a tf topic
 
+from __future__ import print_function
+
 import rospy
 from tf.msg import tfMessage
 
@@ -48,7 +50,7 @@ class TfRemapper:
             if "old" in i and "new" in i:
                 self.mappings[i["old"]] = i["new"]
 
-        print "Applying the following mappings to incoming tf frame ids", self.mappings
+        print("Applying the following mappings to incoming tf frame ids", self.mappings)
         rospy.Subscriber("/tf_old", tfMessage, self.callback)
 
     def callback(self, tf_msg):

--- a/tf/scripts/view_frames
+++ b/tf/scripts/view_frames
@@ -33,9 +33,6 @@
 #
 # Revision $Id: gossipbot.py 1013 2008-05-21 01:08:56Z sfkwc $
 
-## Simple demo of a rospy service client that calls a service to add
-## two integers. 
-
 from __future__ import print_function, with_statement
 
 import sys, time
@@ -54,33 +51,29 @@ import tf
 def listen(duration):
     rospy.init_node("view_frames", anonymous=True)
     tf_listener = tf.TransformListener()
-    print("Listening to /tf for %f seconds"%duration)
+    print("Listening to /tf for {} seconds".format(duration))
     time.sleep(duration)
     print("Done Listening")
     return tf_listener.allFramesAsDot(rospy.Time.now())
-    
 
 def poll(node_name):
-    print("Waiting for service %s/tf_frames"%node_name)
-    rospy.wait_for_service('%s/tf_frames'%node_name)
+    print("Waiting for service {}/tf_frames".format(node_name))
+    rospy.wait_for_service('{}/tf_frames'.format(node_name))
 
     try:
         print("Polling service")
-        tf_frames_proxy = rospy.ServiceProxy('%s/tf_frames'%node_name, FrameGraph)
-
+        tf_frames_proxy = rospy.ServiceProxy('{}/tf_frames'.format(node_name), FrameGraph)
         output = tf_frames_proxy.call(FrameGraphRequest())
 
-    except rospy.ServiceException, e:
-        print("Service call failed: %s"%e)
-        
+    except rospy.ServiceException as e:
+        print("Service call failed: {}".format(e))
+
     return output.dot_graph
 
 def generate(dot_graph):
 
-
     with open('frames.gv', 'w') as outfile:
         outfile.write(dot_graph)
-
 
     try:
         # Check version, make postscript if too old to make pdf
@@ -98,7 +91,7 @@ def generate(dot_graph):
           print('Warning: failed to determine your version of dot.  Assuming v2.16')
         else:
           version = distutils.version.StrictVersion(m.group(1))
-          print('Detected dot version %s' % (version))
+          print('Detected dot version {}'.format(version))
         if version > distutils.version.StrictVersion('2.8'):
           subprocess.check_call(["dot", "-Tpdf", "frames.gv", "-o", "frames.pdf"])
           print("frames.pdf generated")

--- a/tf/scripts/view_frames
+++ b/tf/scripts/view_frames
@@ -36,7 +36,7 @@
 ## Simple demo of a rospy service client that calls a service to add
 ## two integers. 
 
-from __future__ import with_statement
+from __future__ import print_function, with_statement
 
 import sys, time
 import os
@@ -54,24 +54,24 @@ import tf
 def listen(duration):
     rospy.init_node("view_frames", anonymous=True)
     tf_listener = tf.TransformListener()
-    print "Listening to /tf for %f seconds"%duration
+    print("Listening to /tf for %f seconds"%duration)
     time.sleep(duration)
-    print "Done Listening"
+    print("Done Listening")
     return tf_listener.allFramesAsDot(rospy.Time.now())
     
 
 def poll(node_name):
-    print "Waiting for service %s/tf_frames"%node_name
+    print("Waiting for service %s/tf_frames"%node_name)
     rospy.wait_for_service('%s/tf_frames'%node_name)
 
     try:
-        print "Polling service"
+        print("Polling service")
         tf_frames_proxy = rospy.ServiceProxy('%s/tf_frames'%node_name, FrameGraph)
 
         output = tf_frames_proxy.call(FrameGraphRequest())
 
     except rospy.ServiceException, e:
-        print "Service call failed: %s"%e
+        print("Service call failed: %s"%e)
         
     return output.dot_graph
 
@@ -87,26 +87,26 @@ def generate(dot_graph):
         args = ["dot", "-V"]
         try:
             vstr = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()[1]
-        except OSError, ex:
-            print "Warning: Could not execute `dot -V`.  Is graphviz installed?"
+        except OSError as ex:
+            print("Warning: Could not execute `dot -V`.  Is graphviz installed?")
             sys.exit(-1)
         v = distutils.version.StrictVersion('2.16')
         r = re.compile(".*version (\d+\.?\d*)")
-        print vstr
+        print(vstr)
         m = r.search(vstr)
         if not m or not m.group(1):
-          print 'Warning: failed to determine your version of dot.  Assuming v2.16'
+          print('Warning: failed to determine your version of dot.  Assuming v2.16')
         else:
           version = distutils.version.StrictVersion(m.group(1))
-          print 'Detected dot version %s' % (version)
+          print('Detected dot version %s' % (version))
         if version > distutils.version.StrictVersion('2.8'):
           subprocess.check_call(["dot", "-Tpdf", "frames.gv", "-o", "frames.pdf"])
-          print "frames.pdf generated"
+          print("frames.pdf generated")
         else:
           subprocess.check_call(["dot", "-Tps2", "frames.gv", "-o", "frames.ps"])
-          print "frames.ps generated"
+          print("frames.ps generated")
     except subprocess.CalledProcessError:
-        print >> sys.stderr, "failed to generate frames.pdf"        
+        print("failed to generate frames.pdf", file=sys.stderr)
 
 
 if __name__ == '__main__':
@@ -120,7 +120,7 @@ if __name__ == '__main__':
     if not options.node:
         dot_graph = listen(5.0)
     else:
-        print "Generating graph for node: ", options.node
+        print("Generating graph for node: ", options.node)
         dot_graph = poll(options.node)
 
     generate(dot_graph)

--- a/tf/src/tf/__init__.py
+++ b/tf/src/tf/__init__.py
@@ -25,6 +25,8 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import absolute_import
+
 from tf2_ros import TransformException as Exception, ConnectivityException, LookupException, ExtrapolationException
-from listener import Transformer, TransformListener, TransformerROS
-from broadcaster import TransformBroadcaster
+from .listener import Transformer, TransformListener, TransformerROS
+from .broadcaster import TransformBroadcaster

--- a/tf/src/tf/listener.py
+++ b/tf/src/tf/listener.py
@@ -73,14 +73,14 @@ class Transformer(object):
             raise tf2_ros.TransformException("cannot wait for transform without a dedicated thread that listens to incoming TF messages")
         can_transform, error_msg = self._buffer.can_transform(strip_leading_slash(target_frame), strip_leading_slash(source_frame), time, timeout, return_debug_tuple=True)
         if not can_transform:
-            raise tf2_ros.TransformException(error_msg or "no such transformation: \"%s\" -> \"%s\"" % (source_frame, target_frame))
+            raise tf2_ros.TransformException(error_msg or "no such transformation: \"{}\" -> \"{}\"".format(source_frame, target_frame))
 
     def waitForTransformFull(self, target_frame, target_time, source_frame, source_time, fixed_frame, timeout, polling_sleep_duration=None):
         if not self._using_dedicated_thread:
             raise tf2_ros.TransformException("cannot wait for transform without a dedicated thread that listens to incoming TF messages")
         can_transform, error_msg = self._buffer.can_transform_full(strip_leading_slash(target_frame), target_time, strip_leading_slash(source_frame), source_time, strip_leading_slash(fixed_frame), timeout, return_debug_tuple=True)
         if not can_transform:
-            raise tf2_ros.TransformException(error_msg or "no such transformation: \"%s\" -> \"%s\"" % (source_frame, target_frame))
+            raise tf2_ros.TransformException(error_msg or "no such transformation: \"{}\" -> \"{}\"".format(source_frame, target_frame))
 
     def chain(self, target_frame, target_time, source_frame, source_time, fixed_frame):
         return self._buffer._chain( target_frame, target_time, source_frame, source_time, fixed_frame)

--- a/tf/src/tf/tfwtf.py
+++ b/tf/src/tf/tfwtf.py
@@ -32,6 +32,8 @@
 #
 # Revision $Id$
 
+from __future__ import print_function
+
 import time
 
 from roswtf.rules import warning_rule, error_rule
@@ -64,7 +66,7 @@ def rostime_delta(ctx):
 
     errors = []
     for k, v in deltas.items():
-        errors.append("receiving transform from [%s] that differed from ROS time by %ss"%(k, v))
+        errors.append("receiving transform from [{}] that differed from ROS time by {}s".format(k, v))
     return errors
 
 def reparenting(ctx):
@@ -75,7 +77,7 @@ def reparenting(ctx):
             frame_id = t.child_frame_id
             parent_id = t.header.frame_id
             if frame_id in parent_id_map and parent_id_map[frame_id] != parent_id:
-                msg = "reparenting of [%s] to [%s] by [%s]"%(frame_id, parent_id, callerid)
+                msg = "reparenting of [{}] to [{}] by [{}]".format(frame_id, parent_id, callerid)
                 parent_id_map[frame_id] = parent_id
                 if msg not in errors:
                     errors.append(msg)
@@ -103,12 +105,11 @@ def cycle_detection(ctx):
             try:
                 current_frame = parent_id_map[current_frame]
             except KeyError:
-                break 
-            if current_frame == frame:
-                errors.append("Frame %s is in a loop. It's loop has elements:\n%s"% (frame, " -> ".join(frame_list)))
                 break
-            
-            
+            if current_frame == frame:
+                errors.append("Frame {} is in a loop. It's loop has elements:\n{}".format(frame, " -> ".join(frame_list)))
+                break
+
     return errors
 
 def multiple_authority(ctx):
@@ -119,7 +120,7 @@ def multiple_authority(ctx):
             frame_id = t.child_frame_id
             parent_id = t.header.frame_id 
             if frame_id in authority_map and authority_map[frame_id] != callerid:
-                msg = "node [%s] publishing transform [%s] with parent [%s] already published by node [%s]"%(callerid, frame_id, parent_id, authority_map[frame_id])
+                msg = "node [{}] publishing transform [{}] with parent [{}] already published by node [{}]".format(callerid, frame_id, parent_id, authority_map[frame_id])
                 authority_map[frame_id] = callerid
                 if msg not in errors:
                     errors.append(msg)
@@ -137,14 +138,14 @@ def not_normalized(ctx):
             q = t.transform.rotation
             length = math.sqrt(q.x * q.x + q.y * q.y + q.z * q.z + q.w * q.w)
             if math.fabs(length - 1) > 1e-6:
-                errors.append("rotation from [%s] to [%s] is not unit length, %f"%(t.header.frame_id, t.child_frame_id, length))
+                errors.append("rotation from [{}] to [{}] is not unit length, {}".format(t.header.frame_id, t.child_frame_id, length))
     return errors
 
 ################################################################################
 # roswtf PLUGIN
 
 # tf_warnings and tf_errors declare the rules that we actually check
-                
+
 tf_warnings = [
   (no_msgs, "No tf messages"),
   (rostime_delta, "Received out-of-date/future transforms:"),  
@@ -177,7 +178,7 @@ def roswtf_plugin_online(ctx):
     # don't run plugin if tf isn't active as these checks take awhile
     if not is_tf_active():
         return
-    
+
     print("running tf checks, this will take a second...")
     sub1 = rospy.Subscriber('/tf', tf.msg.tfMessage, _tf_handle)
     time.sleep(1.0)
@@ -189,11 +190,9 @@ def roswtf_plugin_online(ctx):
     for r in tf_errors:
         error_rule(r, r[0](ctx), ctx)
 
-    
 # currently no static checks for tf
 #def roswtf_plugin_static(ctx):
 #    for r in tf_warnings:
 #        warning_rule(r, r[0](ctx), ctx)
 #    for r in tf_errors:
 #        error_rule(r, r[0](ctx), ctx)
-        

--- a/tf/src/tf/tfwtf.py
+++ b/tf/src/tf/tfwtf.py
@@ -63,7 +63,7 @@ def rostime_delta(ctx):
                     deltas[callerid]  = secs
 
     errors = []
-    for k, v in deltas.iteritems():
+    for k, v in deltas.items():
         errors.append("receiving transform from [%s] that differed from ROS time by %ss"%(k, v))
     return errors
 
@@ -178,11 +178,11 @@ def roswtf_plugin_online(ctx):
     if not is_tf_active():
         return
     
-    print "running tf checks, this will take a second..."
+    print("running tf checks, this will take a second...")
     sub1 = rospy.Subscriber('/tf', tf.msg.tfMessage, _tf_handle)
     time.sleep(1.0)
     sub1.unregister()
-    print "... tf checks complete"    
+    print("... tf checks complete")
 
     for r in tf_warnings:
         warning_rule(r, r[0](ctx), ctx)

--- a/tf/src/tf/transformations.py
+++ b/tf/src/tf/transformations.py
@@ -672,7 +672,7 @@ def shear_from_matrix(matrix):
     l, V = numpy.linalg.eig(M33)
     i = numpy.where(abs(numpy.real(l) - 1.0) < 1e-4)[0]
     if len(i) < 2:
-        raise ValueError("No two linear independent eigenvectors found %s" % l)
+        raise ValueError("No two linear independent eigenvectors found {}".format(l))
     V = numpy.real(V[:, i]).squeeze().T
     lenorm = -1.0
     for i0, i1 in ((0, 1), (0, 2), (1, 2)):

--- a/tf/test/method_test.py
+++ b/tf/test/method_test.py
@@ -40,4 +40,4 @@ try:
     print(transform_stamped.transform)
     
 except ValueError as e:
-    print("Exception %s Improperly thrown: %s"%(type(e), e))
+    print("Exception {} Improperly thrown: {}".format(type(e), e))

--- a/tf/test/method_test.py
+++ b/tf/test/method_test.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import rospy
 import tf
 import time
@@ -7,35 +9,35 @@ import math
 
 try:
     transform_stamped = tf.TransformStamped()
-    print "getting stamp"
-    print transform_stamped.stamp
+    print("getting stamp")
+    print(transform_stamped.stamp)
 #    mytime = rospy.Time().now()
     mytime = rospy.Time(10,20)
     transform_stamped.stamp = mytime
-    print mytime
-    print "getting stamp", transform_stamped.stamp
-    print "transform:", transform_stamped.transform
+    print(mytime)
+    print("getting stamp", transform_stamped.stamp)
+    print("transform:", transform_stamped.transform)
     transform_stamped.transform.setIdentity()
-    print "after setIdentity()", transform_stamped.transform
+    print("after setIdentity()", transform_stamped.transform)
     #    transform_stamped.transform.basis.setEulerZYX(0,0,0)
     quat = bullet.Quaternion(math.pi/2,0,0)
-    print "quaternion ", quat
+    print("quaternion ", quat)
     transform_stamped.transform.setRotation(quat)
-    print "setting rotation to PI/2\n After setRotation"
-    print transform_stamped.transform
+    print("setting rotation to PI/2\n After setRotation")
+    print(transform_stamped.transform)
 
     other_transform = bullet.Transform()
     other_transform.setIdentity()
     transform_stamped.transform = other_transform
-    print "After assignment of Identity"
-    print transform_stamped.transform
+    print("After assignment of Identity")
+    print(transform_stamped.transform)
 
     other_transform = bullet.Transform()
     other_transform.setIdentity()
     other_transform.setRotation(quat)
     transform_stamped.transform = other_transform
-    print "After assignment of Rotation Transformation"
-    print transform_stamped.transform
+    print("After assignment of Rotation Transformation")
+    print(transform_stamped.transform)
     
-except ValueError, e:
-    print "Exception %s Improperly thrown: %s"%(type(e), e)
+except ValueError as e:
+    print("Exception %s Improperly thrown: %s"%(type(e), e))

--- a/tf/test/python_debug_test.py
+++ b/tf/test/python_debug_test.py
@@ -25,6 +25,8 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import print_function
+
 import rospy
 import tf
 import time
@@ -38,108 +40,108 @@ try:
     time.sleep(1)
 
     # View all frames
-    print "All frames are:\n", tfl.all_frames_as_string()
+    print("All frames are:\n", tfl.all_frames_as_string())
 
     # dot based introspection
-    print "All frame graph is:\n", tfl.all_frames_as_dot()
+    print("All frame graph is:\n", tfl.all_frames_as_dot())
 
     
     # test transforming pose
     po = tf.PoseStamped()
     po.frame_id = "base_link"
-    print "calling transform pose"
+    print("calling transform pose")
     po2 = tfl.transform_pose("/map", po)
 
-    print "po2.pose.this", po2.pose.this
-    print "po.pose.this", po.pose.this
+    print("po2.pose.this", po2.pose.this)
+    print("po.pose.this", po.pose.this)
 
     # test transforming point
     po = tf.PointStamped()
     po.frame_id = "base_link"
     po3 = tfl.transform_point("/map", po)
-    print "po3"
-    print po3.this
+    print("po3")
+    print(po3.this)
 
     # test transforming vector
     po = tf.VectorStamped()
     po.frame_id = "base_link"
     po4 = tfl.transform_vector("/map", po)
-    print po4.this
+    print(po4.this)
     
     # test transforming quaternion
     po = tf.QuaternionStamped()
     po.frame_id = "base_link"
     po5 = tfl.transform_quaternion("/map", po)
-    print "po5",  po5.this
+    print("po5",  po5.this)
     
     tr = tf.TransformStamped()
 
     lps = tf.PoseStamped()
     lps.pose.setIdentity()
-    print "setting stamp"
+    print("setting stamp")
     mytime = rospy.Time(10,20)
     lps.stamp = mytime
-    print mytime
-    print "getting stamp"
+    print(mytime)
+    print("getting stamp")
     output = lps.stamp
-    print output
-    print lps.pose
-    print "setting pose.positon to 1,2,3"
+    print(output)
+    print(lps.pose)
+    print("setting pose.positon to 1,2,3")
     lps.pose.setOrigin( bullet.Vector3(1,2,3))
-    print lps.pose.getOrigin()
-    print lps.pose    
+    print(lps.pose.getOrigin())
+    print(lps.pose)
 
     transform_stamped = tf.TransformStamped()
-    print "getting stamp"
-    print transform_stamped.stamp
+    print("getting stamp")
+    print(transform_stamped.stamp)
 #    mytime = rospy.Time().now()
     mytime = rospy.Time(10,20)
     transform_stamped.stamp = mytime
-    print mytime
-    print "getting stamp", transform_stamped.stamp
-    print "transform:", transform_stamped.transform
+    print(mytime)
+    print("getting stamp", transform_stamped.stamp)
+    print("transform:", transform_stamped.transform)
     transform_stamped.transform.setIdentity()
-    print "after setIdentity()", transform_stamped.transform
+    print("after setIdentity()", transform_stamped.transform)
     #    transform_stamped.transform.basis.setEulerZYX(0,0,0)
     quat = bullet.Quaternion(math.pi/2,0,0)
-    print "quaternion ", quat
+    print("quaternion ", quat)
     transform_stamped.transform.setRotation(quat)
-    print "setting rotation to PI/2",transform_stamped.transform
+    print("setting rotation to PI/2",transform_stamped.transform)
 
 
     pointstamped = tf.PointStamped()
-    print "getting stamp"
-    print pointstamped.stamp
+    print("getting stamp")
+    print(pointstamped.stamp)
 #    mytime = rospy.Time().now()
     mytime = rospy.Time(10,20)
     pointstamped.stamp = mytime
-    print mytime
-    print "getting stamp"
+    print(mytime)
+    print("getting stamp")
     output = pointstamped.stamp
-    print output
-    print pointstamped.point
-    print transform_stamped.transform * pointstamped.point
+    print(output)
+    print(pointstamped.point)
+    print(transform_stamped.transform * pointstamped.point)
 
     pose_only = bullet.Transform(transform_stamped.transform)
-    print "destructing pose_only", pose_only.this    
+    print("destructing pose_only", pose_only.this    )
     pose_only = []
 
     
-    print "Creating copy"
+    print("Creating copy")
     po2_copy = tf.PoseStamped(po2)
-    print "po2_copy.pose", po2_copy.pose.this
-    print "po2.pose", po2.pose.this
+    print("po2_copy.pose", po2_copy.pose.this)
+    print("po2.pose", po2.pose.this)
 
-    print "Creating copy2"
+    print("Creating copy2")
     po2_copy2 = tf.PoseStamped(po2)
-    print "po2_copy2.pose", po2_copy2.pose.this
+    print("po2_copy2.pose", po2_copy2.pose.this)
 
 
-    print "destructing po2  po2.pose is", po2.pose.this
+    print("destructing po2  po2.pose is", po2.pose.this)
     po2 = []
 
 
-    print "destructing po2_copy po2_copy.pose is", po2_copy.pose.this
+    print("destructing po2_copy po2_copy.pose is", po2_copy.pose.this)
     po2_copy = []    
 
     
@@ -147,9 +149,9 @@ try:
     
 
 
-    print "done"
+    print("done")
 
-except ValueError, e:
-    print "Exception %s Improperly thrown: %s"%(type(e), e)
+except ValueError as e:
+    print("Exception %s Improperly thrown: %s"%(type(e), e))
 
 

--- a/tf/test/python_debug_test.py
+++ b/tf/test/python_debug_test.py
@@ -152,6 +152,6 @@ try:
     print("done")
 
 except ValueError as e:
-    print("Exception %s Improperly thrown: %s"%(type(e), e))
+    print("Exception {} Improperly thrown: {}".format(type(e), e))
 
 

--- a/tf/test/testPython.py
+++ b/tf/test/testPython.py
@@ -260,10 +260,9 @@ class TestPython(unittest.TestCase):
         try:
           tr.waitForTransform("PARENT", "THISFRAME", rospy.Time().from_sec(4.0), rospy.Duration(3.0))
           self.assertFalse("This should throw")
-        except tf.Exception, ex:
-          print "successfully caught"
+        except tf.Exception as ex:
+          print("successfully caught")
           pass
-
 
     def test_transformer_wait_for_transform(self):
         tr = tf.Transformer()
@@ -272,7 +271,7 @@ class TestPython(unittest.TestCase):
         try:
           tr.waitForTransform("PARENT", "THISFRAME", rospy.Time().from_sec(4.0), rospy.Duration(3.0))
           self.assertFalse("This should throw")
-        except tf.Exception, ex:
+        except tf.Exception as ex:
           pass
 
         m = geometry_msgs.msg.TransformStamped()
@@ -290,7 +289,7 @@ class TestPython(unittest.TestCase):
 
         try:
           tr.waitForTransform("PARENT", "THISFRAME", rospy.Time().from_sec(4.0), rospy.Duration(3.0))
-        except tf.Exception, ex:
+        except tf.Exception as ex:
           self.assertFalse("This should not throw")
 
 

--- a/tf/test/testPython.py
+++ b/tf/test/testPython.py
@@ -99,7 +99,7 @@ class TestPython(unittest.TestCase):
         t.setTransform(m)
 
         chain = t.chain("A", rospy.Time(0), "C", rospy.Time(0), "B")
-        print("Chain is %s" % chain)
+        print("Chain is {}".format(chain))
         self.assert_("C" in chain)
         self.assert_("B" in chain)
 
@@ -214,9 +214,9 @@ class TestPython(unittest.TestCase):
 
         types = [ "Point", "Pose", "Quaternion", "Vector3" ]
         for t in types:
-            msg = getattr(geometry_msgs.msg, "%sStamped" % t)()
+            msg = getattr(geometry_msgs.msg, "{}Stamped".format(t))()
             msg.header.frame_id = "THISFRAME"
-            msg_t = getattr(tr, "transform%s" % t)("PARENT", msg)
+            msg_t = getattr(tr, "transform{}".format(t))("PARENT", msg)
             self.assertEqual(msg_t.header.frame_id, "PARENT")
 
         # PointCloud is a bit different, so smoke is different

--- a/tf_conversions/src/tf_conversions/__init__.py
+++ b/tf_conversions/src/tf_conversions/__init__.py
@@ -25,4 +25,6 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import absolute_import
+
 from .posemath import *

--- a/tf_conversions/src/tf_conversions/__init__.py
+++ b/tf_conversions/src/tf_conversions/__init__.py
@@ -25,4 +25,4 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from posemath import *
+from .posemath import *

--- a/tf_conversions/src/tf_conversions/posemath.py
+++ b/tf_conversions/src/tf_conversions/posemath.py
@@ -57,7 +57,7 @@ def fromTf(tf):
         ((668.5, 0.0, 0.0), (0.0, 0.0, 0.0, 1.0))
         >>> import tf_conversions.posemath as pm
         >>> p = pm.fromTf(t.lookupTransform('THISFRAME', 'CHILD', rospy.Time(0)))
-        >>> print pm.toMsg(p * p)
+        >>> print(pm.toMsg(p * p))
         position: 
           x: 1337.0
           y: 0.0


### PR DESCRIPTION
This is basically #67 but rebased on indigo-devel. Also, since 707eb4119d641e1776744dd84ae99ab9cfaddd91 removed `pytf.cpp`,  everything touching that is gone. That should make it much easier to merge this.

I squashed the original python fixes by @pallegro and added a few more in a second commit.