### PR TITLE
Fix empty yaml parsing

### DIFF
--- a/tf/src/tf/listener.py
+++ b/tf/src/tf/listener.py
@@ -94,7 +94,7 @@ class Transformer(object):
 
     def getFrameStrings(self):
         """ Not a recommended API, only here for backwards compatibility """
-        data = yaml.load(self._buffer.all_frames_as_yaml())
+        data = yaml.load(self._buffer.all_frames_as_yaml()) or {}
         return [p for p, _ in data.items()]
 
     def getLatestCommonTime(self, source_frame, dest_frame):


### PR DESCRIPTION
Fixes #152

The empty yaml was coming through as a list not a dict so was breaking the expectations.

I used the shorthand `or {}` since I know any valid data won't evaluate to zero. A more complete solution is described here: https://stackoverflow.com/a/35777649/604099