### PR TITLE
Remove dependency on cmake_modules

### DIFF
--- a/eigen_conversions/CMakeLists.txt
+++ b/eigen_conversions/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8)
 project(eigen_conversions)
 
 find_package(orocos_kdl REQUIRED)
-find_package(catkin REQUIRED cmake_modules geometry_msgs std_msgs)
+find_package(catkin REQUIRED geometry_msgs std_msgs)
 find_package(Eigen3 REQUIRED)
 
 include_directories(SYSTEM ${EIGEN3_INCLUDE_DIRS})

--- a/eigen_conversions/package.xml
+++ b/eigen_conversions/package.xml
@@ -17,7 +17,6 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>cmake_modules</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>eigen</build_depend>
   <build_depend>orocos_kdl</build_depend>

--- a/tf_conversions/CMakeLists.txt
+++ b/tf_conversions/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8)
 project(tf_conversions)
 
 find_package(orocos_kdl REQUIRED)
-find_package(catkin REQUIRED cmake_modules geometry_msgs kdl_conversions tf)
+find_package(catkin REQUIRED geometry_msgs kdl_conversions tf)
 find_package(Eigen3 REQUIRED)
 
 catkin_python_setup()

--- a/tf_conversions/package.xml
+++ b/tf_conversions/package.xml
@@ -21,7 +21,6 @@ the next major release cycle (see roadmap).
 
   <buildtool_depend version_gte="0.5.68">catkin</buildtool_depend>
 
-  <build_depend>cmake_modules</build_depend>
   <build_depend>eigen</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>kdl_conversions</build_depend>


### PR DESCRIPTION
This is not needed anymore with the move from Eigen to Eigen3 in 707eb41.