### PR TITLE
Prevent tf_echo rates that result in core dump (0.0) 

### DIFF
--- a/tf/src/tf_echo.cpp
+++ b/tf/src/tf_echo.cpp
@@ -84,6 +84,11 @@ int main(int argc, char ** argv)
     ros::NodeHandle p_nh("~");
     p_nh.param("rate", rate_hz, 1.0);
   }
+  if (rate_hz <= 0.0)
+  {
+    std::cerr << "Echo rate must be > 0.0\n";
+    return -1;
+  }
   ros::Rate rate(rate_hz);
 
   //Instantiate a local listener


### PR DESCRIPTION
And also those that have no limit on update rate at all (<0.0) #159