### PR TITLE
preserve constness to avoid compiler warnings

### DIFF
--- a/tf/include/tf/LinearMath/Vector3.h
+++ b/tf/include/tf/LinearMath/Vector3.h
@@ -623,7 +623,7 @@ public:
 TFSIMD_FORCE_INLINE void	tfSwapScalarEndian(const tfScalar& sourceVal, tfScalar& destVal)
 {
 	unsigned char* dest = (unsigned char*) &destVal;
-	unsigned char* src  = (unsigned char*) &sourceVal;
+	const unsigned char* src  = (const unsigned char*) &sourceVal;
 	dest[0] = src[7];
     dest[1] = src[6];
     dest[2] = src[5];


### PR DESCRIPTION
Minor fix to avoid compiler warning when more string option `-Wcast-qual` is used:
https://travis-ci.org/ros-planning/moveit/jobs/400755736