### PR TITLE
Increase the precision of tf_echo quaternion cout

### DIFF
--- a/tf/src/tf_echo.cpp
+++ b/tf/src/tf_echo.cpp
@@ -118,9 +118,11 @@ int main(int argc, char ** argv)
         tf::Quaternion q = echo_transform.getRotation();
         tf::Vector3 v = echo_transform.getOrigin();
         std::cout << "- Translation: [" << v.getX() << ", " << v.getY() << ", " << v.getZ() << "]" << std::endl;
+        std::cout.precision(6);
         std::cout << "- Rotation: in Quaternion [" << q.getX() << ", " << q.getY() << ", " 
-                  << q.getZ() << ", " << q.getW() << "]" << std::endl
-                  << "            in RPY (radian) [" <<  roll << ", " << pitch << ", " << yaw << "]" << std::endl
+                  << q.getZ() << ", " << q.getW() << "]" << std::endl;
+        std::cout.precision(3);
+        std::cout  <<  "            in RPY (radian) [" <<  roll << ", " << pitch << ", " << yaw << "]" << std::endl
                   << "            in RPY (degree) [" <<  roll*180.0/M_PI << ", " << pitch*180.0/M_PI << ", " << yaw*180.0/M_PI << "]" << std::endl;
 
         //print transform


### PR DESCRIPTION
I ran into some issue because copy and pasting a quaternion from tf_echo is done with std::precision(3).
The lower the precision the less normalized the quaternion will be.

I would like to put this PR as a basis for discussion.