### PR TITLE
Remove `signals` from find_package(Boost COMPONENTS ...)

### DIFF
--- a/tf/CMakeLists.txt
+++ b/tf/CMakeLists.txt
@@ -15,7 +15,7 @@ find_package(catkin REQUIRED COMPONENTS
     std_msgs
     tf2_ros
 )
-find_package(Boost REQUIRED COMPONENTS thread signals system)
+find_package(Boost REQUIRED COMPONENTS thread system)
 
 catkin_python_setup()
 


### PR DESCRIPTION
Same as https://github.com/ros/geometry2/pull/354, but for this repository.