### PR TITLE
fix build issues on Windows

### DIFF
--- a/tf/include/tf/tf.h
+++ b/tf/include/tf/tf.h
@@ -48,6 +48,12 @@
 
 #include <tf2_ros/buffer.h>
 
+// Boost winapi.h includes winerror.h. Subsequently NO_ERROR gets defined
+// and which conflicts with tf::NO_ERROR.
+#if defined(_WIN32) && defined(NO_ERROR)
+  #undef NO_ERROR
+#endif
+
 namespace tf
 {
 /** \brief resolve tf names */

--- a/tf/src/tf.cpp
+++ b/tf/src/tf.cpp
@@ -31,7 +31,7 @@
 
 #include "tf/tf.h"
 #ifdef _WIN32
-#include <time.h>
+#include <ctime>
 #else
 #include <sys/time.h>
 #endif

--- a/tf/src/tf.cpp
+++ b/tf/src/tf.cpp
@@ -30,7 +30,11 @@
 /** \author Tully Foote */
 
 #include "tf/tf.h"
+#ifdef _WIN32
+#include <time.h>
+#else
 #include <sys/time.h>
+#endif
 #include "ros/assert.h"
 #include "ros/ros.h"
 #include <angles/angles.h>


### PR DESCRIPTION
- undefine `NO_ERROR` from winerror.h to resolve name collision with message type
- use `<ctime>` on Windows