### PR TITLE
update how c++11 requirement is added

### DIFF
--- a/tf/CMakeLists.txt
+++ b/tf/CMakeLists.txt
@@ -5,12 +5,7 @@ include(CheckCXXCompilerFlag)
 unset(COMPILER_SUPPORTS_CXX11 CACHE)
 if(MSVC)
   # https://docs.microsoft.com/en-us/cpp/build/reference/std-specify-language-standard-version
-  # MSVC will fail the following check since it does not have the c++11 switch
-  # however, c++11 is always enabled (the newer /std:c++14 is enabled by default)
-  check_cxx_compiler_flag(/std:c++11 COMPILER_SUPPORTS_CXX11)
-  if(COMPILER_SUPPORTS_CXX11)
-    add_compile_options(/std:c++11)
-  endif()
+  # MSVC has c++14 enabled by default, no need to specify c++11
 else()
   check_cxx_compiler_flag(-std=c++11 COMPILER_SUPPORTS_CXX11)
   if(COMPILER_SUPPORTS_CXX11)

--- a/tf/CMakeLists.txt
+++ b/tf/CMakeLists.txt
@@ -1,7 +1,11 @@
 cmake_minimum_required(VERSION 2.8)
 project(tf)
 
-add_compile_options(-std=c++11)
+include(CheckCXXCompilerFlag)
+check_cxx_compiler_flag("-std=c++11" COMPILER_SUPPORTS_CXX11)
+if(COMPILER_SUPPORTS_CXX11)
+  add_compile_options(-std=c++11)
+endif()
 
 find_package(catkin REQUIRED COMPONENTS
     angles

--- a/tf/CMakeLists.txt
+++ b/tf/CMakeLists.txt
@@ -2,9 +2,20 @@ cmake_minimum_required(VERSION 2.8)
 project(tf)
 
 include(CheckCXXCompilerFlag)
-check_cxx_compiler_flag("-std=c++11" COMPILER_SUPPORTS_CXX11)
-if(COMPILER_SUPPORTS_CXX11)
-  add_compile_options(-std=c++11)
+unset(COMPILER_SUPPORTS_CXX11 CACHE)
+if(MSVC)
+  # https://docs.microsoft.com/en-us/cpp/build/reference/std-specify-language-standard-version
+  # MSVC will fail the following check since it does not have the c++11 switch
+  # however, c++11 is always enabled (the newer /std:c++14 is enabled by default)
+  check_cxx_compiler_flag(/std:c++11 COMPILER_SUPPORTS_CXX11)
+  if(COMPILER_SUPPORTS_CXX11)
+    add_compile_options(/std:c++11)
+  endif()
+else()
+  check_cxx_compiler_flag(-std=c++11 COMPILER_SUPPORTS_CXX11)
+  if(COMPILER_SUPPORTS_CXX11)
+    add_compile_options(-std=c++11)
+  endif()
 endif()
 
 find_package(catkin REQUIRED COMPONENTS


### PR DESCRIPTION
update how `c++11` compiler flag is added:
- only add it when it's supported (tested on Ubuntu 18.04)
- add similar logic for MSVC (as mentioned in the comment, this check would fail, but c++11 is always enabled). this pattern could be helpful if later this project moves to c++14 (which is an available switch in MSVC)

the other way to do this is to use `target_compile_features(mylib PUBLIC cxx_std_11)` from [cmake](https://cmake.org/cmake/help/v3.8/manual/cmake-compile-features.7.html#requiring-language-standards), but this would mean to add this line for every target. would this be preferred instead of adding a global `c++11` flag?