### PR TITLE
Allow to choose output precision in tf_echo

### DIFF
--- a/tf/src/tf_echo.cpp
+++ b/tf/src/tf_echo.cpp
@@ -104,6 +104,7 @@ int main(int argc, char ** argv)
   //Instantiate a local listener
   echoListener echoListener;
 
+
   std::string source_frameid = std::string(argv[1]);
   std::string target_frameid = std::string(argv[2]);
 
@@ -147,3 +148,4 @@ int main(int argc, char ** argv)
 
   return 0;
 };
+

--- a/tf/src/tf_echo.cpp
+++ b/tf/src/tf_echo.cpp
@@ -70,7 +70,7 @@ int main(int argc, char ** argv)
     return -1;
   }
 
-  ros::NodeHandle nh;
+  ros::NodeHandle nh("~");
 
   double rate_hz;
   if (argc == 4)
@@ -81,8 +81,7 @@ int main(int argc, char ** argv)
   else
   {
     // read rate parameter
-    ros::NodeHandle p_nh("~");
-    p_nh.param("rate", rate_hz, 1.0);
+    nh.param("rate", rate_hz, 1.0);
   }
   if (rate_hz <= 0.0)
   {
@@ -91,9 +90,19 @@ int main(int argc, char ** argv)
   }
   ros::Rate rate(rate_hz);
 
+  int precision(3);
+  if (nh.getParam("precision", precision))
+  {
+    if (precision < 1)
+    {
+      std::cerr << "Precision must be > 0\n";
+      return -1;
+    }
+    printf("Precision default value was overriden, new value: %d\n", precision);
+  }
+
   //Instantiate a local listener
   echoListener echoListener;
-
 
   std::string source_frameid = std::string(argv[1]);
   std::string target_frameid = std::string(argv[2]);
@@ -110,7 +119,7 @@ int main(int argc, char ** argv)
       {
         tf::StampedTransform echo_transform;
         echoListener.tf.lookupTransform(source_frameid, target_frameid, ros::Time(), echo_transform);
-        std::cout.precision(3);
+        std::cout.precision(precision);
         std::cout.setf(std::ios::fixed,std::ios::floatfield);
         std::cout << "At time " << echo_transform.stamp_.toSec() << std::endl;
         double yaw, pitch, roll;
@@ -138,4 +147,3 @@ int main(int argc, char ** argv)
 
   return 0;
 };
-


### PR DESCRIPTION
Improves #171 

With this PR it is possible to choose the precision of the pose output by passing an argument to the node:

```bash
rosrun tf tf_echo base tool0 _precision:=12
```

I am inspecting robot poses and I need at least millimeter precision. This allows getting the precision without cluttering the default output.

Example run:
```bash
$ rosrun tf tf_echo base tool0 _precision:=8
[ INFO] [1556030892.141355409]: Precision: 8
Failure at 1556030893.154955017
Exception thrown:Could not find a connection between 'base' and 'tool0' because they are not part of the same tree.Tf has two or more unconnected trees.
The current list of frames is:
Frame base exists with parent base_link.
Frame flange exists with parent link_6.
Frame tool0 exists with parent link_6.

Failure at 1556030893.155026131
Exception thrown:Could not find a connection between 'base' and 'tool0' because they are not part of the same tree.Tf has two or more unconnected trees.
The current list of frames is:
Frame base exists with parent base_link.
Frame flange exists with parent link_6.
Frame tool0 exists with parent link_6.

At time 1556030893.30690527
- Translation: [1.62458820, -0.14177884, 0.48463830]
- Rotation: in Quaternion [0.70637963, 0.70496671, -0.05111242, 0.03791152]
            in RPY (radian) [-3.12293846, 0.12599536, 1.56997085]
            in RPY (degree) [-178.93119320, 7.21900259, 89.95270386]

```