### PR TITLE
Remove trailing semicolons from tf sources

### DIFF
--- a/tf/include/tf/tf.h
+++ b/tf/include/tf/tf.h
@@ -69,7 +69,7 @@ std::string resolve(const std::string& prefix, const std::string& frame_name);
 std::string strip_leading_slash(const std::string& frame_name);
 
 /** \deprecated This has been renamed to tf::resolve */
-ROS_DEPRECATED static inline std::string remap(const std::string& prefix, const std::string& frame_name) { return tf::resolve(prefix, frame_name);} ;
+ROS_DEPRECATED static inline std::string remap(const std::string& prefix, const std::string& frame_name) { return tf::resolve(prefix, frame_name);}
 
 enum ErrorValues { NO_ERROR = 0, LOOKUP_ERROR, CONNECTIVITY_ERROR, EXTRAPOLATION_ERROR};
 
@@ -421,7 +421,7 @@ inline void assertQuaternionValid(const tf::Quaternion & q)
     ss << "Quaternion malformed, magnitude: " << q.x()*q.x() + q.y()*q.y() + q.z()*q.z() + q.w()*q.w() << " should be 1.0" <<std::endl;
     throw tf::InvalidArgument(ss.str());
   }  //  ROS_ASSERT(std::fabs(q.x()*q.x() + q.y()*q.y() + q.z*q.z() + q.w()*q.w() - 1 < 0.01));
-};
+}
 
 /** \brief Throw InvalidArgument if quaternion is malformed */
 inline void assertQuaternionValid(const geometry_msgs::Quaternion & q)
@@ -439,6 +439,6 @@ inline void assertQuaternionValid(const geometry_msgs::Quaternion & q)
     ss << "Quaternion malformed, magnitude: " << q.x*q.x + q.y*q.y + q.z*q.z + q.w*q.w << " should be 1.0" <<std::endl;
     throw tf::InvalidArgument(ss.str());
   }  //  ROS_ASSERT(std::fabs(q.x()*q.x() + q.y()*q.y() + q.z*q.z() + q.w()*q.w() - 1 < 0.01));
-};
+}
 }
 #endif //TF_TF_H

--- a/tf/include/tf/transform_datatypes.h
+++ b/tf/include/tf/transform_datatypes.h
@@ -74,7 +74,7 @@ class Stamped : public T{
 template <typename T> 
 bool operator==(const Stamped<T> &a, const Stamped<T> &b) {
   return a.frame_id_ == b.frame_id_ && a.stamp_ == b.stamp_ && static_cast<const T&>(a) == static_cast<const T&>(b);
-};
+}
 
 
 /** \brief The Stamped Transform datatype used by tf */
@@ -85,7 +85,7 @@ public:
   std::string frame_id_; ///< The frame_id of the coordinate frame  in which this transform is defined
   std::string child_frame_id_; ///< The frame_id of the coordinate frame this transform defines
   StampedTransform(const tf::Transform& input, const ros::Time& timestamp, const std::string & frame_id, const std::string & child_frame_id):
-    tf::Transform (input), stamp_ ( timestamp ), frame_id_ (frame_id), child_frame_id_(child_frame_id){ };
+    tf::Transform (input), stamp_ ( timestamp ), frame_id_ (frame_id), child_frame_id_(child_frame_id){ }
 
   /** \brief Default constructor only to be used for preallocation */
   StampedTransform() { };
@@ -98,7 +98,7 @@ public:
 /** \brief Comparison operator for StampedTransform */
 static inline bool operator==(const StampedTransform &a, const StampedTransform &b) {
   return a.frame_id_ == b.frame_id_ && a.child_frame_id_ == b.child_frame_id_ && a.stamp_ == b.stamp_ && static_cast<const tf::Transform&>(a) == static_cast<const tf::Transform&>(b);
-};
+}
 
 
 /** \brief convert Quaternion msg to Quaternion */
@@ -110,7 +110,7 @@ static inline void quaternionMsgToTF(const geometry_msgs::Quaternion& msg, Quate
       ROS_WARN("MSG to TF: Quaternion Not Properly Normalized");
       bt.normalize();
     }
-};
+}
 /** \brief convert Quaternion to Quaternion msg*/
 static inline void quaternionTFToMsg(const Quaternion& bt, geometry_msgs::Quaternion& msg) 
 {
@@ -125,7 +125,7 @@ static inline void quaternionTFToMsg(const Quaternion& bt, geometry_msgs::Quater
   {
     msg.x = bt.x(); msg.y = bt.y(); msg.z = bt.z();  msg.w = bt.w();
   }
-};
+}
 
 /** \brief Helper function for getting yaw from a Quaternion */
 static inline double getYaw(const Quaternion& bt_q){
@@ -195,68 +195,68 @@ static inline tf::Quaternion createIdentityQuaternion()
   Quaternion q;
   q.setRPY(0,0,0);
   return q;
-};
+}
 
 /** \brief convert QuaternionStamped msg to Stamped<Quaternion> */
 static inline void quaternionStampedMsgToTF(const geometry_msgs::QuaternionStamped & msg, Stamped<Quaternion>& bt)
-{quaternionMsgToTF(msg.quaternion, bt); bt.stamp_ = msg.header.stamp; bt.frame_id_ = msg.header.frame_id;};
+{quaternionMsgToTF(msg.quaternion, bt); bt.stamp_ = msg.header.stamp; bt.frame_id_ = msg.header.frame_id;}
 /** \brief convert Stamped<Quaternion> to QuaternionStamped msg*/
 static inline void quaternionStampedTFToMsg(const Stamped<Quaternion>& bt, geometry_msgs::QuaternionStamped & msg)
-{quaternionTFToMsg(bt, msg.quaternion); msg.header.stamp = bt.stamp_; msg.header.frame_id = bt.frame_id_;};
+{quaternionTFToMsg(bt, msg.quaternion); msg.header.stamp = bt.stamp_; msg.header.frame_id = bt.frame_id_;}
 
 /** \brief convert Vector3 msg to Vector3 */
-static inline void vector3MsgToTF(const geometry_msgs::Vector3& msg_v, Vector3& bt_v) {bt_v = Vector3(msg_v.x, msg_v.y, msg_v.z);};
+static inline void vector3MsgToTF(const geometry_msgs::Vector3& msg_v, Vector3& bt_v) {bt_v = Vector3(msg_v.x, msg_v.y, msg_v.z);}
 /** \brief convert Vector3 to Vector3 msg*/
-static inline void vector3TFToMsg(const Vector3& bt_v, geometry_msgs::Vector3& msg_v) {msg_v.x = bt_v.x(); msg_v.y = bt_v.y(); msg_v.z = bt_v.z();};
+static inline void vector3TFToMsg(const Vector3& bt_v, geometry_msgs::Vector3& msg_v) {msg_v.x = bt_v.x(); msg_v.y = bt_v.y(); msg_v.z = bt_v.z();}
 
 /** \brief convert Vector3Stamped msg to Stamped<Vector3> */
 static inline void vector3StampedMsgToTF(const geometry_msgs::Vector3Stamped & msg, Stamped<Vector3>& bt)
-{vector3MsgToTF(msg.vector, bt); bt.stamp_ = msg.header.stamp; bt.frame_id_ = msg.header.frame_id;};
+{vector3MsgToTF(msg.vector, bt); bt.stamp_ = msg.header.stamp; bt.frame_id_ = msg.header.frame_id;}
 /** \brief convert Stamped<Vector3> to Vector3Stamped msg*/
 static inline void vector3StampedTFToMsg(const Stamped<Vector3>& bt, geometry_msgs::Vector3Stamped & msg)
-{vector3TFToMsg(bt, msg.vector); msg.header.stamp = bt.stamp_; msg.header.frame_id = bt.frame_id_;};
+{vector3TFToMsg(bt, msg.vector); msg.header.stamp = bt.stamp_; msg.header.frame_id = bt.frame_id_;}
 
 
 /** \brief convert Point msg to Point */
-static inline void pointMsgToTF(const geometry_msgs::Point& msg_v, Point& bt_v) {bt_v = Vector3(msg_v.x, msg_v.y, msg_v.z);};
+static inline void pointMsgToTF(const geometry_msgs::Point& msg_v, Point& bt_v) {bt_v = Vector3(msg_v.x, msg_v.y, msg_v.z);}
 /** \brief convert Point to Point msg*/
-static inline void pointTFToMsg(const Point& bt_v, geometry_msgs::Point& msg_v) {msg_v.x = bt_v.x(); msg_v.y = bt_v.y(); msg_v.z = bt_v.z();};
+static inline void pointTFToMsg(const Point& bt_v, geometry_msgs::Point& msg_v) {msg_v.x = bt_v.x(); msg_v.y = bt_v.y(); msg_v.z = bt_v.z();}
 
 /** \brief convert PointStamped msg to Stamped<Point> */
 static inline void pointStampedMsgToTF(const geometry_msgs::PointStamped & msg, Stamped<Point>& bt)
-{pointMsgToTF(msg.point, bt); bt.stamp_ = msg.header.stamp; bt.frame_id_ = msg.header.frame_id;};
+{pointMsgToTF(msg.point, bt); bt.stamp_ = msg.header.stamp; bt.frame_id_ = msg.header.frame_id;}
 /** \brief convert Stamped<Point> to PointStamped msg*/
 static inline void pointStampedTFToMsg(const Stamped<Point>& bt, geometry_msgs::PointStamped & msg)
-{pointTFToMsg(bt, msg.point); msg.header.stamp = bt.stamp_; msg.header.frame_id = bt.frame_id_;};
+{pointTFToMsg(bt, msg.point); msg.header.stamp = bt.stamp_; msg.header.frame_id = bt.frame_id_;}
 
 
 /** \brief convert Transform msg to Transform */
 static inline void transformMsgToTF(const geometry_msgs::Transform& msg, Transform& bt)
-{bt = Transform(Quaternion(msg.rotation.x, msg.rotation.y, msg.rotation.z, msg.rotation.w), Vector3(msg.translation.x, msg.translation.y, msg.translation.z));};
+{bt = Transform(Quaternion(msg.rotation.x, msg.rotation.y, msg.rotation.z, msg.rotation.w), Vector3(msg.translation.x, msg.translation.y, msg.translation.z));}
 /** \brief convert Transform to Transform msg*/
 static inline void transformTFToMsg(const Transform& bt, geometry_msgs::Transform& msg)
-{vector3TFToMsg(bt.getOrigin(), msg.translation);  quaternionTFToMsg(bt.getRotation(), msg.rotation);};
+{vector3TFToMsg(bt.getOrigin(), msg.translation);  quaternionTFToMsg(bt.getRotation(), msg.rotation);}
 
 /** \brief convert TransformStamped msg to tf::StampedTransform */
 static inline void transformStampedMsgToTF(const geometry_msgs::TransformStamped & msg, StampedTransform& bt)
-{transformMsgToTF(msg.transform, bt); bt.stamp_ = msg.header.stamp; bt.frame_id_ = msg.header.frame_id; bt.child_frame_id_ = msg.child_frame_id;};
+{transformMsgToTF(msg.transform, bt); bt.stamp_ = msg.header.stamp; bt.frame_id_ = msg.header.frame_id; bt.child_frame_id_ = msg.child_frame_id;}
 /** \brief convert tf::StampedTransform to TransformStamped msg*/
 static inline void transformStampedTFToMsg(const StampedTransform& bt, geometry_msgs::TransformStamped & msg)
-{transformTFToMsg(bt, msg.transform); msg.header.stamp = bt.stamp_; msg.header.frame_id = bt.frame_id_; msg.child_frame_id = bt.child_frame_id_;};
+{transformTFToMsg(bt, msg.transform); msg.header.stamp = bt.stamp_; msg.header.frame_id = bt.frame_id_; msg.child_frame_id = bt.child_frame_id_;}
 
 /** \brief convert Pose msg to Pose */
 static inline void poseMsgToTF(const geometry_msgs::Pose& msg, Pose& bt)
-{bt = Transform(Quaternion(msg.orientation.x, msg.orientation.y, msg.orientation.z, msg.orientation.w), Vector3(msg.position.x, msg.position.y, msg.position.z));};
+{bt = Transform(Quaternion(msg.orientation.x, msg.orientation.y, msg.orientation.z, msg.orientation.w), Vector3(msg.position.x, msg.position.y, msg.position.z));}
 /** \brief convert Pose to Pose msg*/
 static inline void poseTFToMsg(const Pose& bt, geometry_msgs::Pose& msg)
-{pointTFToMsg(bt.getOrigin(), msg.position);  quaternionTFToMsg(bt.getRotation(), msg.orientation);};
+{pointTFToMsg(bt.getOrigin(), msg.position);  quaternionTFToMsg(bt.getRotation(), msg.orientation);}
 
 /** \brief convert PoseStamped msg to Stamped<Pose> */
 static inline void poseStampedMsgToTF(const geometry_msgs::PoseStamped & msg, Stamped<Pose>& bt)
-{poseMsgToTF(msg.pose, bt); bt.stamp_ = msg.header.stamp; bt.frame_id_ = msg.header.frame_id;};
+{poseMsgToTF(msg.pose, bt); bt.stamp_ = msg.header.stamp; bt.frame_id_ = msg.header.frame_id;}
 /** \brief convert Stamped<Pose> to PoseStamped msg*/
 static inline void poseStampedTFToMsg(const Stamped<Pose>& bt, geometry_msgs::PoseStamped & msg)
-{poseTFToMsg(bt, msg.pose); msg.header.stamp = bt.stamp_; msg.header.frame_id = bt.frame_id_;};
+{poseTFToMsg(bt, msg.pose); msg.header.stamp = bt.stamp_; msg.header.frame_id = bt.frame_id_;}
 
 
 

--- a/tf/src/empty_listener.cpp
+++ b/tf/src/empty_listener.cpp
@@ -53,4 +53,4 @@ int main(int argc, char** argv)
     rate.sleep();
   }
   return 0;
-};
+}

--- a/tf/src/static_transform_publisher.cpp
+++ b/tf/src/static_transform_publisher.cpp
@@ -128,5 +128,5 @@ int main(int argc, char ** argv)
   }
 
 
-};
+}
 

--- a/tf/src/tf.cpp
+++ b/tf/src/tf.cpp
@@ -154,7 +154,7 @@ std::string assert_resolved(const std::string& prefix, const std::string& frame_
 {
   ROS_DEBUG("tf::assert_resolved just calls tf::resolve");
   return tf::resolve(prefix, frame_id);
-};
+}
 
 std::string tf::resolve(const std::string& prefix, const std::string& frame_name)
 {
@@ -189,7 +189,7 @@ std::string tf::resolve(const std::string& prefix, const std::string& frame_name
     composite.append(frame_name);
     return composite;
   }
-};
+}
 
 
 std::string tf::strip_leading_slash(const std::string& frame_name)
@@ -217,7 +217,7 @@ Transformer::Transformer(bool interpolating,
 Transformer::~Transformer()
 {
 
-};
+}
 
 
 void Transformer::clear()
@@ -232,7 +232,7 @@ bool Transformer::setTransform(const StampedTransform& transform, const std::str
   transformStampedTFToMsg(transform, msgtf);
   return tf2_buffer_ptr_->setTransform(msgtf, authority);
   
-};
+}
 
 
 void Transformer::lookupTransform(const std::string& target_frame, const std::string& source_frame,
@@ -243,7 +243,7 @@ void Transformer::lookupTransform(const std::string& target_frame, const std::st
                                 strip_leading_slash(source_frame), time);
   transformStampedMsgToTF(output, transform);
   return;
-};
+}
 
 
 void Transformer::lookupTransform(const std::string& target_frame,const ros::Time& target_time, const std::string& source_frame,
@@ -254,7 +254,7 @@ void Transformer::lookupTransform(const std::string& target_frame,const ros::Tim
                                 strip_leading_slash(source_frame), source_time,
                                 strip_leading_slash(fixed_frame));
   transformStampedMsgToTF(output, transform);
-};
+}
 
 
 void Transformer::lookupTwist(const std::string& tracking_frame, const std::string& observation_frame,
@@ -263,7 +263,7 @@ void Transformer::lookupTwist(const std::string& tracking_frame, const std::stri
 {
   // ref point is origin of tracking_frame, ref_frame = obs_frame
   lookupTwist(tracking_frame, observation_frame, observation_frame, tf::Point(0,0,0), tracking_frame, time, averaging_interval, twist);
-};
+}
 
 
 
@@ -343,7 +343,7 @@ void Transformer::lookupTwist(const std::string& tracking_frame, const std::stri
   twist.angular.y =  out_rot.y();
   twist.angular.z =  out_rot.z();
 
-};
+}
 
 bool Transformer::waitForTransform(const std::string& target_frame, const std::string& source_frame,
                                    const ros::Time& time,
@@ -370,7 +370,7 @@ bool Transformer::canTransform(const std::string& target_frame,const ros::Time& 
   return tf2_buffer_ptr_->canTransform(strip_leading_slash(target_frame), target_time,
                                   strip_leading_slash(source_frame), source_time,
                                   strip_leading_slash(fixed_frame), error_msg);
-};
+}
 
 bool Transformer::waitForTransform(const std::string& target_frame,const ros::Time& target_time, const std::string& source_frame,
                                    const ros::Time& source_time, const std::string& fixed_frame,
@@ -380,13 +380,13 @@ bool Transformer::waitForTransform(const std::string& target_frame,const ros::Ti
   return tf2_buffer_ptr_->canTransform(strip_leading_slash(target_frame), target_time,
                                   strip_leading_slash(source_frame), source_time,
                                   strip_leading_slash(fixed_frame), timeout, error_msg);
-};
+}
 
 
 bool Transformer::getParent(const std::string& frame_id, ros::Time time, std::string& parent) const
 {
   return tf2_buffer_ptr_->_getParent(strip_leading_slash(frame_id), time, parent);
-};
+}
 
 
 bool Transformer::frameExists(const std::string& frame_id_str) const
@@ -460,7 +460,7 @@ void Transformer::transformQuaternion(const std::string& target_frame, const Sta
   stamped_out.setData( transform * stamped_in);
   stamped_out.stamp_ = transform.stamp_;
   stamped_out.frame_id_ = target_frame;
-};
+}
 
 
 void Transformer::transformVector(const std::string& target_frame,
@@ -478,7 +478,7 @@ void Transformer::transformVector(const std::string& target_frame,
 
   stamped_out.stamp_ = transform.stamp_;
   stamped_out.frame_id_ = target_frame;
-};
+}
 
 
 void Transformer::transformPoint(const std::string& target_frame, const Stamped<Point>& stamped_in, Stamped<Point>& stamped_out) const
@@ -489,7 +489,7 @@ void Transformer::transformPoint(const std::string& target_frame, const Stamped<
   stamped_out.setData(transform * stamped_in);
   stamped_out.stamp_ = transform.stamp_;
   stamped_out.frame_id_ = target_frame;
-};
+}
 
 void Transformer::transformPose(const std::string& target_frame, const Stamped<Pose>& stamped_in, Stamped<Pose>& stamped_out) const
 {
@@ -499,7 +499,7 @@ void Transformer::transformPose(const std::string& target_frame, const Stamped<P
   stamped_out.setData(transform * stamped_in);
   stamped_out.stamp_ = transform.stamp_;
   stamped_out.frame_id_ = target_frame;
-};
+}
 
 
 void Transformer::transformQuaternion(const std::string& target_frame, const ros::Time& target_time,
@@ -516,7 +516,7 @@ void Transformer::transformQuaternion(const std::string& target_frame, const ros
   stamped_out.setData( transform * stamped_in);
   stamped_out.stamp_ = transform.stamp_;
   stamped_out.frame_id_ = target_frame;
-};
+}
 
 
 void Transformer::transformVector(const std::string& target_frame, const ros::Time& target_time,
@@ -537,7 +537,7 @@ void Transformer::transformVector(const std::string& target_frame, const ros::Ti
 
   stamped_out.stamp_ = transform.stamp_;
   stamped_out.frame_id_ = target_frame;
-};
+}
 
 
 void Transformer::transformPoint(const std::string& target_frame, const ros::Time& target_time,
@@ -553,7 +553,7 @@ void Transformer::transformPoint(const std::string& target_frame, const ros::Tim
   stamped_out.setData(transform * stamped_in);
   stamped_out.stamp_ = transform.stamp_;
   stamped_out.frame_id_ = target_frame;
-};
+}
 
 void Transformer::transformPose(const std::string& target_frame, const ros::Time& target_time,
                                 const Stamped<Pose>& stamped_in,
@@ -568,7 +568,7 @@ void Transformer::transformPose(const std::string& target_frame, const ros::Time
   stamped_out.setData(transform * stamped_in);
   stamped_out.stamp_ = transform.stamp_;
   stamped_out.frame_id_ = target_frame;
-};
+}
 
 boost::signals2::connection Transformer::addTransformsChangedListener(boost::function<void(void)> callback)
 {

--- a/tf/src/tf_echo.cpp
+++ b/tf/src/tf_echo.cpp
@@ -42,12 +42,12 @@ public:
   echoListener()
   {
 
-  };
+  }
 
   ~echoListener()
   {
 
-  };
+  }
 
 private:
 
@@ -137,5 +137,5 @@ int main(int argc, char ** argv)
     }
 
   return 0;
-};
+}
 

--- a/tf/src/transform_broadcaster.cpp
+++ b/tf/src/transform_broadcaster.cpp
@@ -44,7 +44,7 @@ namespace tf {
 TransformBroadcaster::TransformBroadcaster():
   tf2_broadcaster_()
 {
-};
+}
 
 void TransformBroadcaster::sendTransform(const geometry_msgs::TransformStamped & msgtf)
 {

--- a/tf/src/transform_listener.cpp
+++ b/tf/src/transform_listener.cpp
@@ -37,7 +37,7 @@ std::string tf::remap(const std::string& frame_id)
 {
   ros::NodeHandle n("~");
   return tf::resolve(getPrefixParam(n), frame_id);
-};
+}
 
 
 TransformListener::TransformListener(ros::Duration max_cache_time, bool spin_thread):

--- a/tf/test/cache_unittest.cpp
+++ b/tf/test/cache_unittest.cpp
@@ -40,7 +40,7 @@ void seed_rand()
   timeval temp_time_struct;
   gettimeofday(&temp_time_struct,NULL);
   srand(temp_time_struct.tv_usec);
-};
+}
 
 using namespace tf;
 

--- a/tf/test/quaternion.cpp
+++ b/tf/test/quaternion.cpp
@@ -43,7 +43,7 @@ void seed_rand()
   timeval temp_time_struct;
   gettimeofday(&temp_time_struct,NULL);
   srand(temp_time_struct.tv_usec);
-};
+}
 
 void testQuatRPY(tf::Quaternion q_baseline)
 {

--- a/tf/test/testBroadcaster.cpp
+++ b/tf/test/testBroadcaster.cpp
@@ -54,7 +54,7 @@ public:
     else
       count ++;
     //std::cerr<<count<<std::endl;
-  };
+  }
 
   // A function to call to send data periodically
   void test_vector () {
@@ -71,7 +71,7 @@ public:
     else
       count1 ++;
     //std::cerr<<count1<<std::endl;
-  };
+  }
 private:
   int count;
   int count1;
@@ -96,5 +96,5 @@ int main(int argc, char ** argv)
   }
 
   return 0;
-};
+}
 

--- a/tf/test/testListener.cpp
+++ b/tf/test/testListener.cpp
@@ -57,5 +57,5 @@ int main(int argc, char ** argv)
   int ret = RUN_ALL_TESTS();
 
   return ret;
-};
+}
 

--- a/tf/test/tf_unittest.cpp
+++ b/tf/test/tf_unittest.cpp
@@ -44,7 +44,7 @@ void seed_rand()
   timeval temp_time_struct;
   gettimeofday(&temp_time_struct,NULL);
   srand(temp_time_struct.tv_usec);
-};
+}
 
 void generate_rand_vectors(double scale, uint64_t runs, std::vector<double>& xvalues, std::vector<double>& yvalues, std::vector<double>&zvalues)
 {
@@ -1816,7 +1816,7 @@ TEST(tf, NoExtrapolationExceptionFromParent)
 
 
 
-};
+}
 
 
 
@@ -1899,7 +1899,7 @@ TEST(tf, ExtrapolationFromOneValue)
   
   EXPECT_FALSE(excepted);
 
-};
+}
 
 
 

--- a/tf/test/transform_listener_unittest.cpp
+++ b/tf/test/transform_listener_unittest.cpp
@@ -38,7 +38,7 @@ void seed_rand()
   timeval temp_time_struct;
   gettimeofday(&temp_time_struct,NULL);
   srand(temp_time_struct.tv_usec);
-};
+}
 
 void generate_rand_vectors(double scale, uint64_t runs, std::vector<double>& xvalues, std::vector<double>& yvalues, std::vector<double>&zvalues)
 {

--- a/tf/test/velocity_test.cpp
+++ b/tf/test/velocity_test.cpp
@@ -172,7 +172,7 @@ TEST_F(LinearVelocitySquareTest, LinearVelocityToThreeFrames)
       EXPECT_STREQ("", ex.what());
     }
   }
-};
+}
 
 TEST_F(AngularVelocitySquareTest, AngularVelocityAlone)
 {
@@ -232,7 +232,7 @@ TEST_F(AngularVelocitySquareTest, AngularVelocityAlone)
   {
     EXPECT_STREQ("", ex.what());
   }
-};
+}
 
 TEST_F(AngularVelocitySquareTest, AngularVelocityOffsetChildFrameInX)
 {
@@ -292,7 +292,7 @@ TEST_F(AngularVelocitySquareTest, AngularVelocityOffsetChildFrameInX)
   {
     EXPECT_STREQ("", ex.what());
   }
-};
+}
 
 TEST_F(AngularVelocitySquareTest, AngularVelocityOffsetParentFrameInZ)
 {
@@ -352,7 +352,7 @@ TEST_F(AngularVelocitySquareTest, AngularVelocityOffsetParentFrameInZ)
   {
     EXPECT_STREQ("", ex.what());
   }
-};
+}
 
 
 int main(int argc, char **argv){


### PR DESCRIPTION
This PR removes trailing semicolons at the end of function declarations, from sources under tf/

The motivation behind this PR lies in the fact that I regularly use the compiler flag `-Wpedantic`, and I was getting lots of warnings after including tf headers.

I ran the library's unit tests locally to verify that functionality stays the same after the aforementioned changes.