### PR TITLE
TypeError: string pattern on a bytes-like object

### DIFF
--- a/tf/scripts/view_frames
+++ b/tf/scripts/view_frames
@@ -86,7 +86,7 @@ def generate(dot_graph):
         v = distutils.version.StrictVersion('2.16')
         r = re.compile(".*version (\d+\.?\d*)")
         print(vstr)
-        m = r.search(vstr)
+        m = r.search(vstr.decode('utf-8'))
         if not m or not m.group(1):
           print('Warning: failed to determine your version of dot.  Assuming v2.16')
         else:


### PR DESCRIPTION
Wanted to use

$ rosrun tf view_frames

Listening to /tf for 5.0 seconds
Done Listening
b'dot - graphviz version 2.40.1 (20161225.0304)\n'
Traceback (most recent call last):
  File "/opt/ros/melodic/lib/tf/view_frames", line 119, in <module>
    generate(dot_graph)
  File "/opt/ros/melodic/lib/tf/view_frames", line 89, in generate
    m = r.search(vstr)
TypeError: cannot use a string pattern on a bytes-like object

Simply adding the .decode('utf-8') to m = r.search(vstr.decode('utf-8')) fixed it.