### PR TITLE
Add rostest include dirs

### DIFF
--- a/tf/CMakeLists.txt
+++ b/tf/CMakeLists.txt
@@ -73,10 +73,10 @@ target_link_libraries(static_transform_publisher ${PROJECT_NAME})
 
 # Tests
 if(CATKIN_ENABLE_TESTING AND NOT ANDROID)
-
 find_package(rostest REQUIRED)
 
 catkin_add_gtest(tf_unittest test/tf_unittest.cpp)
+target_include_directories(tf_unittest PRIVATE ${rostest_INCLUDE_DIRS})
 target_link_libraries(tf_unittest ${PROJECT_NAME})
 
 catkin_add_gtest(tf_quaternion_unittest test/quaternion.cpp)

--- a/tf/CMakeLists.txt
+++ b/tf/CMakeLists.txt
@@ -73,6 +73,7 @@ target_link_libraries(static_transform_publisher ${PROJECT_NAME})
 
 # Tests
 if(CATKIN_ENABLE_TESTING AND NOT ANDROID)
+
 find_package(rostest REQUIRED)
 
 catkin_add_gtest(tf_unittest test/tf_unittest.cpp)


### PR DESCRIPTION
This fixes a build failure when building the `tests` target seen in the Noetic CI job for ros-infrastructure/ros_buildfarm_config#151

To reproduce this failure locally:

```
catkin_make_isolated --cmake-args -DCATKIN_ENABLE_TESTING=1 --make-args tests
```