### PR TITLE
setTransformStatic not implemented and confusing

### DIFF
--- a/tf/src/tf/listener.py
+++ b/tf/src/tf/listener.py
@@ -62,6 +62,9 @@ class Transformer(object):
     def setTransform(self, transform, authority="default_authority"):
         self._buffer.set_transform(transform, authority)
 
+    def setTransformStatic(self, transform, authority="default_authority"):
+        self._buffer.set_transform_static(transform, authority)
+
     def canTransform(self, target_frame, source_frame, time):
         return self._buffer.can_transform(strip_leading_slash(target_frame), strip_leading_slash(source_frame), time)
 


### PR DESCRIPTION
In the `TransformerROS` class implemented in tf, the method for setting tf is implemented such as:

https://github.com/ros/geometry/blob/00a32d024af476bf50822e6df2fe2ec97765b1a9/tf/src/tf/listener.py#L62-L63

But it can be confusing when using static tfs. Since no `setTransformStatic` method exist, we would "naturally" fallback to the `setTransform`, which is wrong since it doesn't call `_buffer.set_transform_static` and result in a bad graph. 

To be correct, when setting static tfs to a `TransformerROS` instance we would use something like this

```python
transformer = TransformerROS()
transformer._buffer.set_transform_static(my_static_tf, "default_authority")
```

Otherwise, lookup might fail.

Hope you find this useful :)