### PR TITLE
Bump CMake version to avoid CMP0048 warning

### DIFF
--- a/eigen_conversions/CMakeLists.txt
+++ b/eigen_conversions/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.0.2)
 project(eigen_conversions)
 
 find_package(orocos_kdl REQUIRED)

--- a/geometry/CMakeLists.txt
+++ b/geometry/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(geometry)
 find_package(catkin REQUIRED)
 catkin_metapackage()

--- a/kdl_conversions/CMakeLists.txt
+++ b/kdl_conversions/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.0.2)
 project(kdl_conversions)
 
 find_package(catkin REQUIRED geometry_msgs)

--- a/tf/CMakeLists.txt
+++ b/tf/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.0.2)
 project(tf)
 
 include(CheckCXXCompilerFlag)

--- a/tf_conversions/CMakeLists.txt
+++ b/tf_conversions/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.0.2)
 project(tf_conversions)
 
 find_package(orocos_kdl REQUIRED)


### PR DESCRIPTION
This bumps the minimum CMake version to 3.0.2, which is the [minimum supported by ROS Kinetic](https://www.ros.org/reps/rep-0003.html#kinetic-kame-may-2016-may-2021) and new enough to default to the NEW behavior of [CMP0048](https://cmake.org/cmake/help/v3.0/policy/CMP0048.html). This avoids a CMake warning when building and testing this package in Debian Buster and Ubuntu Focal.

example:
```
==> Processing catkin package: 'eigen_conversions'
==> cmake /home/sloretz/ws/noetic-misc/src/geometry/eigen_conversions -DCATKIN_DEVEL_PREFIX=/home/sloretz/ws/noetic-misc/devel_isolated/eigen_conversions -DCMAKE_INSTALL_PREFIX=/home/sloretz/ws/noetic-misc/install_isolated -G Unix Makefiles in '/home/sloretz/ws/noetic-misc/build_isolated/eigen_conversions'
CMake Warning (dev) at CMakeLists.txt:2 (project):
  Policy CMP0048 is not set: project() command manages VERSION variables.
  Run "cmake --help-policy CMP0048" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.

  The following variable(s) would be set to empty:

    CMAKE_PROJECT_VERSION
    CMAKE_PROJECT_VERSION_MAJOR
    CMAKE_PROJECT_VERSION_MINOR
    CMAKE_PROJECT_VERSION_PATCH
This warning is for project developers.  Use -Wno-dev to suppress it.
```

ros/catkin#1052