### PR TITLE
Use process_time() to fix test failure using Python 3.8

### DIFF
--- a/tf/test/testPython.py
+++ b/tf/test/testPython.py
@@ -9,6 +9,16 @@ import sensor_msgs.msg
 
 import tf
 
+
+def process_time():
+    try:
+        # Available in Python >= 3.3 required in Python >= 3.8
+        return time.process_time()
+    except AttributeError:
+        # Python < 3.3 compatibility
+        return time.clock()
+
+
 class Mock:
   pass
 
@@ -127,14 +137,14 @@ class TestPython(unittest.TestCase):
         self.assertEqual(t.waitForTransform("PARENT", "THISFRAME", rospy.Time(15), timeout), None)
 
         # Verify exception still thrown with unavailable time near timeout
-        start = time.clock()
+        start = process_time()
         self.assertRaises(tf.Exception, lambda: t.waitForTransform("PARENT", "THISFRAME", rospy.Time(25), timeout))
-        elapsed_time_within_epsilon(time.clock() - start, timeout.to_sec(), epsilon)
+        elapsed_time_within_epsilon(process_time() - start, timeout.to_sec(), epsilon)
 
         # Verify exception stil thrown with non-existing frames near timeout
-        start = time.clock()
+        start = process_time()
         self.assertRaises(tf.Exception, lambda: t.waitForTransform("MANDALAY", "JUPITER", rospy.Time(), timeout))
-        elapsed_time_within_epsilon(time.clock() - start, timeout.to_sec(), epsilon)
+        elapsed_time_within_epsilon(process_time() - start, timeout.to_sec(), epsilon)
 
     def test_cache_time(self):
         # Vary cache_time and confirm its effect on ExtrapolationException from lookupTransform().


### PR DESCRIPTION
This fixes a test failure on Ubuntu Focal which uses Python 3.8.


```
[100%] Built target _run_tests_tf_gtest
...E
======================================================================
ERROR: test_wait_for_transform (testPython.TestPython)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/sloretz/ws/noetic-misc/src/geometry/tf/test/testPython.py", line 130, in test_wait_for_transform
    start = time.clock()
AttributeError: module 'time' has no attribute 'clock'

----------------------------------------------------------------------
Ran 10 tests in 3.574s

FAILED (errors=1)
-- run_tests.py: verify result "/home/sloretz/ws/noetic-misc/build_isolated/tf/test_results/tf/nosetests-test.testPython.py.xml"
[100%] Built target _run_tests_tf_nosetests_test.testPython.py
[100%] Built target _run_tests_tf_nosetests
[100%] Built target _run_tests_tf
[100%] Built target run_tests
<== Finished processing package [11 of 17]: 'tf'
```