### PR TITLE
Replace kdl packages with rosdep keys

### DIFF
--- a/eigen_conversions/package.xml
+++ b/eigen_conversions/package.xml
@@ -19,11 +19,11 @@
 
   <build_depend>geometry_msgs</build_depend>
   <build_depend>eigen</build_depend>
-  <build_depend>orocos_kdl</build_depend>
+  <build_depend>liborocos-kdl-dev</build_depend>
   <build_depend>std_msgs</build_depend>
 
   <run_depend>geometry_msgs</run_depend>
   <run_depend>eigen</run_depend>
-  <run_depend>orocos_kdl</run_depend>
+  <run_depend>liborocos-kdl</run_depend>
   <run_depend>std_msgs</run_depend>
 </package>

--- a/kdl_conversions/package.xml
+++ b/kdl_conversions/package.xml
@@ -15,8 +15,8 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>geometry_msgs</build_depend>
-  <build_depend>orocos_kdl</build_depend>
+  <build_depend>liborocos-kdl-dev</build_depend>
 
   <run_depend>geometry_msgs</run_depend>
-  <run_depend>orocos_kdl</run_depend>
+  <run_depend>liborocos-kdl</run_depend>
 </package>

--- a/tf_conversions/package.xml
+++ b/tf_conversions/package.xml
@@ -24,14 +24,14 @@ the next major release cycle (see roadmap).
   <build_depend>eigen</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>kdl_conversions</build_depend>
-  <build_depend>orocos_kdl</build_depend>
+  <build_depend>liborocos-kdl-dev</build_depend>
   <build_depend>tf</build_depend>
 
   <run_depend>eigen</run_depend>
   <run_depend>geometry_msgs</run_depend>
   <run_depend>kdl_conversions</run_depend>
-  <run_depend>orocos_kdl</run_depend>
-  <run_depend>python_orocos_kdl</run_depend>
+  <run_depend>liborocos-kdl</run_depend>
+  <run_depend>python3-pykdl</run_depend>
   <run_depend>tf</run_depend>
 
   <export>


### PR DESCRIPTION
I tested these packages using a system install of `liborocos-kdl-dev` and `python3-pykdl` on Debian Buster and Ubuntu Focal and the tests seem to pass. This PR replaces the orocos KDL ROS packages with to-be-added rosdep keys.

This PR would make the `melodic-devel` branch work for ROS Noetic only, it should probably be retargeted at a new branch `noetic-devel`. If multiple ROS distros on the same branch is desired, then I think the `package.xml` would need to be upgraded to format 3 and conditional dependencies on `ROS_DISTRO` would need to be used.

See also ros/rosdistro#23841