### PR TITLE
[melodic] use modern c++11 for portability.

### DIFF
--- a/tf/CMakeLists.txt
+++ b/tf/CMakeLists.txt
@@ -1,16 +1,9 @@
 cmake_minimum_required(VERSION 2.8)
 project(tf)
 
-include(CheckCXXCompilerFlag)
-unset(COMPILER_SUPPORTS_CXX11 CACHE)
-if(MSVC)
-  # https://docs.microsoft.com/en-us/cpp/build/reference/std-specify-language-standard-version
-  # MSVC has c++14 enabled by default, no need to specify c++11
-else()
-  check_cxx_compiler_flag(-std=c++11 COMPILER_SUPPORTS_CXX11)
-  if(COMPILER_SUPPORTS_CXX11)
-    add_compile_options(-std=c++11)
-  endif()
+# Melodic default to C++14
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
 endif()
 
 find_package(catkin REQUIRED COMPONENTS

--- a/tf/include/tf/tf.h
+++ b/tf/include/tf/tf.h
@@ -49,6 +49,12 @@
 #include <tf2_ros/buffer.h>
 #include <ros/macros.h>
 
+// Boost winapi.h includes winerror.h. Subsequently NO_ERROR gets defined
+// and which conflicts with tf::NO_ERROR.
+#if defined(_WIN32) && defined(NO_ERROR)
+  #undef NO_ERROR
+#endif
+
 // Import/export for windows dll's and visibility for gcc shared libraries.
 #ifdef ROS_BUILD_SHARED_LIBS // ros is being built around shared libraries
   #ifdef tf_EXPORTS // we are building a shared lib/dll

--- a/tf/src/tf.cpp
+++ b/tf/src/tf.cpp
@@ -30,7 +30,6 @@
 /** \author Tully Foote */
 
 #include "tf/tf.h"
-#include <sys/time.h>
 #include "ros/assert.h"
 #include "ros/ros.h"
 #include <angles/angles.h>

--- a/tf/test/cache_unittest.cpp
+++ b/tf/test/cache_unittest.cpp
@@ -27,9 +27,10 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <ctime>
+#include <cstdlib>
 #include <gtest/gtest.h>
 #include <tf/tf.h>
-#include <sys/time.h>
 #include "tf/LinearMath/Vector3.h"
 #include "tf/LinearMath/Matrix3x3.h"
 
@@ -37,9 +38,7 @@
 void seed_rand()
 {
   //Seed random number generator with current microseond count
-  timeval temp_time_struct;
-  gettimeofday(&temp_time_struct,NULL);
-  srand(temp_time_struct.tv_usec);
+  std::srand(std::time(0));
 }
 
 using namespace tf;
@@ -59,7 +58,7 @@ TEST(TimeCache, Repeatability)
   
   for ( uint64_t i = 1; i < runs ; i++ )
   {
-    values[i] = 10.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    values[i] = 10.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
     std::stringstream ss;
     ss << values[i];
     t.frame_id_ = ss.str();
@@ -95,7 +94,7 @@ TEST(TimeCache, RepeatabilityReverseInsertOrder)
   
   for ( int i = runs -1; i >= 0 ; i-- )
   {
-    values[i] = 10.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    values[i] = 10.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
     t.stamp_ = ros::Time().fromNSec(i);
 
     TransformStorage stor(t, i, 0);
@@ -127,7 +126,7 @@ TEST(TimeCache, RepeatabilityRandomInsertOrder)
 
   for ( uint64_t i = 0; i <runs ; i++ )
   {
-    values[i] = 10.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    values[i] = 10.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
     t.stamp_ = ros::Time().fromNSec(i);
 
     TransformStorage stor(t, i, 0);
@@ -158,7 +157,7 @@ TEST(TimeCache, ZeroAtFront)
   
   for ( uint64_t i = 0; i <runs ; i++ )
   {
-    values[i] = 10.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    values[i] = 10.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
     t.stamp_ = ros::Time().fromNSec(i);
 
     TransformStorage stor(t, i, 0);
@@ -212,9 +211,9 @@ TEST(TimeCache, CartesianInterpolation)
   {
     for (uint64_t step = 0; step < 2 ; step++)
     {
-      xvalues[step] = 10.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
-      yvalues[step] = 10.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
-      zvalues[step] = 10.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+      xvalues[step] = 10.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+      yvalues[step] = 10.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+      zvalues[step] = 10.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
     
       t.setOrigin(tf::Vector3(xvalues[step], yvalues[step], zvalues[step]));
       t.stamp_ = ros::Time().fromNSec(step * 100 + offset);
@@ -257,9 +256,9 @@ TEST(TimeCache, ReparentingInterpolationProtection)
 
   for (uint64_t step = 0; step < 2 ; step++)
   {
-    xvalues[step] = 10.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
-    yvalues[step] = 10.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
-    zvalues[step] = 10.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    xvalues[step] = 10.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    yvalues[step] = 10.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    zvalues[step] = 10.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
     
     t.setOrigin(tf::Vector3(xvalues[step], yvalues[step], zvalues[step]));
     t.stamp_ = ros::Time().fromNSec(step * 100 + offset);
@@ -312,9 +311,9 @@ TEST(TimeCache, CartesianExtrapolation)
   {
     for (uint64_t step = 0; step < 2 ; step++)
     {
-      xvalues[step] = 10.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
-      yvalues[step] = 10.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
-      zvalues[step] = 10.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+      xvalues[step] = 10.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+      yvalues[step] = 10.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+      zvalues[step] = 10.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
     
       t.setOrigin(tf::Vector3(xvalues[step], yvalues[step], zvalues[step]));
       t.stamp_ = ros::Time().fromNSec(step * 100 + offset);
@@ -349,9 +348,9 @@ TEST(Bullet, Slerp)
   
   for (uint64_t i = 0 ; i < runs ; i++)
   {
-    q2.setEuler(1.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX,
-                1.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX,
-                1.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX);
+    q2.setEuler(1.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX,
+                1.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX,
+                1.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX);
     
     
     tf::Quaternion q3 = slerp(q1,q2,0.5);
@@ -383,9 +382,9 @@ TEST(TimeCache, AngularInterpolation)
   {
     for (uint64_t step = 0; step < 2 ; step++)
     {
-      yawvalues[step] = 10.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX / 100.0;
-      pitchvalues[step] = 0;//10.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
-      rollvalues[step] = 0;//10.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+      yawvalues[step] = 10.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX / 100.0;
+      pitchvalues[step] = 0;//10.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+      rollvalues[step] = 0;//10.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
       quats[step].setRPY(yawvalues[step], pitchvalues[step], rollvalues[step]);
       t.setRotation(quats[step]);
       t.stamp_ = ros::Time().fromNSec(offset + (step * 100)); //step = 0 or 1

--- a/tf/test/operator_overload.cpp
+++ b/tf/test/operator_overload.cpp
@@ -27,8 +27,9 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <ctime>
+#include <cstdlib>
 #include <vector>
-#include <sys/time.h>
 
 #include "tf/LinearMath/Transform.h"
 
@@ -36,9 +37,7 @@
 void seed_rand()
 {
   //Seed random number generator with current microseond count
-  timeval temp_time_struct;
-  gettimeofday(&temp_time_struct,NULL);
-  srand(temp_time_struct.tv_usec);
+  std::srand(std::time(0));
 };
 
 
@@ -50,9 +49,9 @@ int main(int argc, char **argv){
   std::vector<double> xvalues(runs), yvalues(runs), zvalues(runs);
   for ( unsigned int i = 0; i < runs ; i++ )
   {
-    xvalues[i] = 1.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
-    yvalues[i] = 1.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
-    zvalues[i] = 1.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    xvalues[i] = 1.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    yvalues[i] = 1.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    zvalues[i] = 1.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
   }
     
   //Useful Operator Overload

--- a/tf/test/quaternion.cpp
+++ b/tf/test/quaternion.cpp
@@ -28,8 +28,9 @@
  */
 
 #include <vector>
-#include <sys/time.h>
 #include <cstdio>
+#include <ctime>
+#include <cstdlib>
 #include <gtest/gtest.h>
 
 #include "tf/LinearMath/Transform.h"
@@ -40,9 +41,7 @@ double epsilon = 10E-6;
 void seed_rand()
 {
   //Seed random number generator with current microseond count
-  timeval temp_time_struct;
-  gettimeofday(&temp_time_struct,NULL);
-  srand(temp_time_struct.tv_usec);
+  std::srand(std::time(0));
 }
 
 void testQuatRPY(tf::Quaternion q_baseline)
@@ -82,9 +81,9 @@ TEST(tf, Quaternion)
   std::vector<double> xvalues(runs), yvalues(runs), zvalues(runs);
   for ( unsigned int i = 0; i < runs ; i++ )
   {
-    xvalues[i] = 1.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
-    yvalues[i] = 1.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
-    zvalues[i] = 1.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    xvalues[i] = 1.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    yvalues[i] = 1.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    zvalues[i] = 1.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
   }
   
   

--- a/tf/test/testBroadcaster.cpp
+++ b/tf/test/testBroadcaster.cpp
@@ -27,6 +27,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <chrono>
+#include <thread>
 #include "tf/transform_broadcaster.h"
 #include "ros/ros.h"
 
@@ -92,7 +94,7 @@ int main(int argc, char ** argv)
       //Send some data
       myTestBroadcaster.test();
       myTestBroadcaster.test_vector();
-      usleep(1000);
+      std::this_thread::sleep_for(std::chrono::microseconds(1000));
   }
 
   return 0;

--- a/tf/test/test_transform_datatypes.cpp
+++ b/tf/test/test_transform_datatypes.cpp
@@ -29,7 +29,6 @@
 
 #include <gtest/gtest.h>
 #include <tf/tf.h>
-#include <sys/time.h>
 
 #include "tf/LinearMath/Vector3.h"
 

--- a/tf/test/tf_benchmark.cpp
+++ b/tf/test/tf_benchmark.cpp
@@ -27,18 +27,17 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <ctime>
+#include <cstdlib>
 #include <gtest/gtest.h>
 #include <tf/tf.h>
-#include <sys/time.h>
 
 #include "tf/LinearMath/Vector3.h"
 
 void seed_rand()
 {
   //Seed random number generator with current microseond count
-  timeval temp_time_struct;
-  gettimeofday(&temp_time_struct,NULL);
-  srand(temp_time_struct.tv_usec);
+  std::srand(std::time(0));
 };
 
 void generate_rand_vectors(double scale, uint64_t runs, std::vector<double>& xvalues, std::vector<double>& yvalues, std::vector<double>&zvalues)
@@ -46,9 +45,9 @@ void generate_rand_vectors(double scale, uint64_t runs, std::vector<double>& xva
   seed_rand();
   for ( uint64_t i = 0; i < runs ; i++ )
   {
-    xvalues[i] = 1.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
-    yvalues[i] = 1.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
-    zvalues[i] = 1.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    xvalues[i] = 1.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    yvalues[i] = 1.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    zvalues[i] = 1.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
   }
 }
 
@@ -184,9 +183,9 @@ TEST(tf_benchmark, benchmarkExhaustiveSearch)
   std::vector<double> xvalues(runs), yvalues(runs), zvalues(runs);
   for ( uint64_t i = 0; i < runs ; i++ )
   {
-    xvalues[i] = 10.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
-    yvalues[i] = 10.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
-    zvalues[i] = 10.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    xvalues[i] = 10.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    yvalues[i] = 10.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    zvalues[i] = 10.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
 
     StampedTransform tranStamped(tf::Transform(tf::Quaternion(0,0,0,1), tf::Vector3(xvalues[i],yvalues[i],zvalues[i])), ros::Time().fromNSec(10.0 + i), "my_parent", "child");
     mTR.setTransform(tranStamped);

--- a/tf/test/tf_unittest.cpp
+++ b/tf/test/tf_unittest.cpp
@@ -27,9 +27,11 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <ctime>
+#include <cstdlib>
+#include <cmath>
 #include <gtest/gtest.h>
 #include <tf/tf.h>
-#include <sys/time.h>
 #include <ros/ros.h>
 #include "tf/LinearMath/Vector3.h"
 
@@ -41,9 +43,7 @@ using namespace tf;
 void seed_rand()
 {
   //Seed random number generator with current microseond count
-  timeval temp_time_struct;
-  gettimeofday(&temp_time_struct,NULL);
-  srand(temp_time_struct.tv_usec);
+  std::srand(std::time(0));
 }
 
 void generate_rand_vectors(double scale, uint64_t runs, std::vector<double>& xvalues, std::vector<double>& yvalues, std::vector<double>&zvalues)
@@ -51,9 +51,9 @@ void generate_rand_vectors(double scale, uint64_t runs, std::vector<double>& xva
   seed_rand();
   for ( uint64_t i = 0; i < runs ; i++ )
   {
-    xvalues[i] = 1.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
-    yvalues[i] = 1.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
-    zvalues[i] = 1.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    xvalues[i] = 1.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    yvalues[i] = 1.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    zvalues[i] = 1.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
   }
 }
 
@@ -755,7 +755,7 @@ TEST(tf, setTransformNoInsertWithNan)
   StampedTransform tranStamped(tf::Transform(tf::Quaternion(0,0,0,1), tf::Vector3(0,0,0)), ros::Time().fromNSec(10.0), "same_frame", "other_frame");
   EXPECT_TRUE(mTR.setTransform(tranStamped));
 
-  tranStamped.setOrigin(tf::Point(1.0,1.0,0.0/0.0));
+  tranStamped.setOrigin(tf::Point(1.0,1.0,NAN));
   EXPECT_TRUE(std::isnan(tranStamped.getOrigin().z()));
   EXPECT_FALSE(mTR.setTransform(tranStamped));
 
@@ -785,9 +785,9 @@ TEST(tf, TransformTransformsCartesian)
   std::vector<double> xvalues(runs), yvalues(runs), zvalues(runs);
   for ( uint64_t i = 0; i < runs ; i++ )
   {
-    xvalues[i] = 10.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
-    yvalues[i] = 10.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
-    zvalues[i] = 10.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    xvalues[i] = 10.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    yvalues[i] = 10.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    zvalues[i] = 10.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
 
     StampedTransform tranStamped(tf::Transform(tf::Quaternion(0,0,0,1), tf::Vector3(xvalues[i],yvalues[i],zvalues[i])), ros::Time().fromNSec(10.0 + i), "my_parent", "child");
     mTR.setTransform(tranStamped);
@@ -841,12 +841,12 @@ TEST(tf, TransformTransformToOwnFrame)
   std::vector<double> xvalues(runs), yvalues(runs), zvalues(runs), yawvalues(runs),  pitchvalues(runs),  rollvalues(runs);
   for ( uint64_t i = 0; i < runs ; i++ )
   {
-    xvalues[i] = 10.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
-    yvalues[i] = 10.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
-    zvalues[i] = 10.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
-    yawvalues[i] = 10.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
-    pitchvalues[i] = 10.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
-    rollvalues[i] = 10.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    xvalues[i] = 10.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    yvalues[i] = 10.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    zvalues[i] = 10.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    yawvalues[i] = 10.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    pitchvalues[i] = 10.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    rollvalues[i] = 10.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
 
     tf::Quaternion qt;
     qt.setRPY(yawvalues[i],pitchvalues[i],rollvalues[i]);
@@ -910,9 +910,9 @@ TEST(tf, TransformPointCartesian)
   std::vector<double> xvalues(runs), yvalues(runs), zvalues(runs);
   for ( uint64_t i = 0; i < runs ; i++ )
   {
-    xvalues[i] = 10.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
-    yvalues[i] = 10.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
-    zvalues[i] = 10.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    xvalues[i] = 10.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    yvalues[i] = 10.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    zvalues[i] = 10.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
 
     StampedTransform tranStamped(tf::Transform(tf::Quaternion(0,0,0,1), tf::Vector3(xvalues[i],yvalues[i],zvalues[i])), ros::Time().fromNSec(10 + i), "my_parent", "child");
     mTR.setTransform(tranStamped);
@@ -925,9 +925,9 @@ TEST(tf, TransformPointCartesian)
   for ( uint64_t i = 0; i < runs ; i++ )
 
   {
-    double x =10.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
-    double y =10.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
-    double z =10.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    double x =10.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    double y =10.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    double z =10.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
     Stamped<Point> invec (tf::Vector3(x,y,z), ros::Time().fromNSec(10 + i), "child");
 
     try{
@@ -958,9 +958,9 @@ TEST(tf, TransformVectorCartesian)
   std::vector<double> xvalues(runs), yvalues(runs), zvalues(runs);
   for ( uint64_t i = 0; i < runs ; i++ )
   {
-    xvalues[i] = 10.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
-    yvalues[i] = 10.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
-    zvalues[i] = 10.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    xvalues[i] = 10.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    yvalues[i] = 10.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    zvalues[i] = 10.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
 
     StampedTransform tranStamped(tf::Transform(tf::Quaternion(0,0,0,1), tf::Vector3(xvalues[i],yvalues[i],zvalues[i])), ros::Time().fromNSec(10 + i), "my_parent", "child");
     mTR.setTransform(tranStamped);
@@ -973,9 +973,9 @@ TEST(tf, TransformVectorCartesian)
   for ( uint64_t i = 0; i < runs ; i++ )
 
   {
-    double x =10.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
-    double y =10.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
-    double z =10.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    double x =10.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    double y =10.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    double z =10.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
     Stamped<Point> invec (tf::Vector3(x,y,z), ros::Time().fromNSec(10 + i), "child");
 
     try{
@@ -1006,9 +1006,9 @@ TEST(tf, TransformQuaternionCartesian)
   std::vector<double> xvalues(runs), yvalues(runs), zvalues(runs);
   for ( uint64_t i = 0; i < runs ; i++ )
   {
-    xvalues[i] = 1.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
-    yvalues[i] = 1.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
-    zvalues[i] = 1.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    xvalues[i] = 1.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    yvalues[i] = 1.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    zvalues[i] = 1.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
 
 
     StampedTransform tranStamped(tf::Transform(tf::Quaternion(0,0,0,1), tf::Vector3(xvalues[i],yvalues[i],zvalues[i])), ros::Time().fromNSec(10 + i), "my_parent", "child");
@@ -1215,9 +1215,9 @@ TEST(tf, ListOneInverse)
   std::vector<double> xvalues(runs), yvalues(runs), zvalues(runs);
   for ( uint64_t i = 0; i < runs ; i++ )
   {
-    xvalues[i] = 10.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
-    yvalues[i] = 10.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
-    zvalues[i] = 10.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    xvalues[i] = 10.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    yvalues[i] = 10.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    zvalues[i] = 10.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
 
     StampedTransform tranStamped(tf::Transform(tf::Quaternion(0,0,0,1), tf::Vector3(xvalues[i],yvalues[i],zvalues[i])), ros::Time().fromNSec(10 + i),  "my_parent", "child");
     mTR.setTransform(tranStamped);
@@ -1259,9 +1259,9 @@ TEST(tf, ListTwoInverse)
   std::vector<double> xvalues(runs), yvalues(runs), zvalues(runs);
   for ( unsigned int i = 0; i < runs ; i++ )
   {
-    xvalues[i] = 10.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
-    yvalues[i] = 10.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
-    zvalues[i] = 10.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    xvalues[i] = 10.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    yvalues[i] = 10.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    zvalues[i] = 10.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
 
     StampedTransform tranStamped(tf::Transform(tf::Quaternion(0,0,0,1), tf::Vector3(xvalues[i],yvalues[i],zvalues[i])), ros::Time().fromNSec(10 + i),  "my_parent", "child");
     mTR.setTransform(tranStamped);
@@ -1306,9 +1306,9 @@ TEST(tf, ListOneForward)
   std::vector<double> xvalues(runs), yvalues(runs), zvalues(runs);
   for ( uint64_t i = 0; i < runs ; i++ )
   {
-    xvalues[i] = 10.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
-    yvalues[i] = 10.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
-    zvalues[i] = 10.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    xvalues[i] = 10.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    yvalues[i] = 10.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    zvalues[i] = 10.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
 
     StampedTransform tranStamped(tf::Transform(tf::Quaternion(0,0,0,1), tf::Vector3(xvalues[i],yvalues[i],zvalues[i])), ros::Time().fromNSec(10 + i),  "my_parent", "child");
     mTR.setTransform(tranStamped);
@@ -1350,9 +1350,9 @@ TEST(tf, ListTwoForward)
   std::vector<double> xvalues(runs), yvalues(runs), zvalues(runs);
   for ( unsigned int i = 0; i < runs ; i++ )
   {
-    xvalues[i] = 10.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
-    yvalues[i] = 10.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
-    zvalues[i] = 10.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    xvalues[i] = 10.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    yvalues[i] = 10.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    zvalues[i] = 10.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
 
     StampedTransform tranStamped(tf::Transform(tf::Quaternion(0,0,0,1), tf::Vector3(xvalues[i],yvalues[i],zvalues[i])), ros::Time().fromNSec(10 + i),  "my_parent", "child");
     mTR.setTransform(tranStamped);
@@ -1396,9 +1396,9 @@ TEST(tf, TransformThrougRoot)
   std::vector<double> xvalues(runs), yvalues(runs), zvalues(runs);
   for ( unsigned int i = 0; i < runs ; i++ )
   {
-    xvalues[i] = 10.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
-    yvalues[i] = 10.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
-    zvalues[i] = 10.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    xvalues[i] = 10.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    yvalues[i] = 10.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    zvalues[i] = 10.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
 
     StampedTransform tranStamped(tf::Transform(tf::Quaternion(0,0,0,1), tf::Vector3(xvalues[i],yvalues[i],zvalues[i])), ros::Time().fromNSec(1000 + i*100),  "my_parent", "childA");
     mTR.setTransform(tranStamped);
@@ -1442,9 +1442,9 @@ TEST(tf, TransformThroughNO_PARENT)
   std::vector<double> xvalues(runs), yvalues(runs), zvalues(runs);
   for ( unsigned int i = 0; i < runs ; i++ )
   {
-    xvalues[i] = 10.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
-    yvalues[i] = 10.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
-    zvalues[i] = 10.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    xvalues[i] = 10.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    yvalues[i] = 10.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    zvalues[i] = 10.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
 
     StampedTransform tranStamped(tf::Transform(tf::Quaternion(0,0,0,1), tf::Vector3(xvalues[i],yvalues[i],zvalues[i])), ros::Time().fromNSec(10 + i),  "my_parentA", "childA");
     mTR.setTransform(tranStamped);
@@ -2392,7 +2392,7 @@ TEST(tf, assertQuaternionValid)
 
   // check NaNs
   q.setValue(1,0,0,0);
-  q.setX(0.0/0.0);
+  q.setX(NAN);
   EXPECT_TRUE(expectInvalidQuaternion(q));
   q.setX(1.0);
 
@@ -2400,11 +2400,11 @@ TEST(tf, assertQuaternionValid)
   EXPECT_TRUE(expectInvalidQuaternion(q));
   q.setY(0.0);
 
-  q.setZ(0.0/0.0);
+  q.setZ(NAN);
   EXPECT_TRUE(expectInvalidQuaternion(q));
   q.setZ(0.0);
 
-  q.setW(0.0/0.0);
+  q.setW(NAN);
   EXPECT_TRUE(expectInvalidQuaternion(q));
   q.setW(0.0);
 
@@ -2447,7 +2447,7 @@ TEST(tf, assertQuaternionMsgValid)
 
   // check NaNs
   q.x = 1.0; q.y = 0.0; q.z = 0.0; q.w = 0.0;
-  q.x = 0.0/0.0;
+  q.x = NAN;
   EXPECT_TRUE(expectInvalidQuaternion(q));
   q.x = 1.0;
 
@@ -2455,11 +2455,11 @@ TEST(tf, assertQuaternionMsgValid)
   EXPECT_TRUE(expectInvalidQuaternion(q));
   q.y = 0.0;
 
-  q.z = 0.0/0.0;
+  q.z = NAN;
   EXPECT_TRUE(expectInvalidQuaternion(q));
   q.z = 0.0;
 
-  q.w = 0.0/0.0;
+  q.w = NAN;
   EXPECT_TRUE(expectInvalidQuaternion(q));
   q.w = 0.0;
 

--- a/tf/test/tf_unittest_future.cpp
+++ b/tf/test/tf_unittest_future.cpp
@@ -1,6 +1,7 @@
+#include <ctime>
+#include <cstdlib>
 #include <gtest/gtest.h>
 #include <tf/tf.h>
-#include <sys/time.h>
 
 #include "tf/LinearMath/Vector3.h"
 
@@ -9,9 +10,7 @@ using namespace tf;
 void seed_rand()
 {
   //Seed random number generator with current microseond count
-  timeval temp_time_struct;
-  gettimeofday(&temp_time_struct,NULL);
-  srand(temp_time_struct.tv_usec);
+  std::srand(std::time(0));
 };
 
 

--- a/tf/test/transform_listener_unittest.cpp
+++ b/tf/test/transform_listener_unittest.cpp
@@ -27,17 +27,16 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <ctime>
+#include <cstdlib>
 #include <gtest/gtest.h>
 #include <tf/transform_listener.h>
-#include <sys/time.h>
 
 
 void seed_rand()
 {
   //Seed random number generator with current microseond count
-  timeval temp_time_struct;
-  gettimeofday(&temp_time_struct,NULL);
-  srand(temp_time_struct.tv_usec);
+  std::srand(std::time(0));
 }
 
 void generate_rand_vectors(double scale, uint64_t runs, std::vector<double>& xvalues, std::vector<double>& yvalues, std::vector<double>&zvalues)
@@ -45,9 +44,9 @@ void generate_rand_vectors(double scale, uint64_t runs, std::vector<double>& xva
   seed_rand();
   for ( uint64_t i = 0; i < runs ; i++ )
   {
-    xvalues[i] = 1.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
-    yvalues[i] = 1.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
-    zvalues[i] = 1.0 * ((double) rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    xvalues[i] = 1.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    yvalues[i] = 1.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
+    zvalues[i] = 1.0 * ((double) std::rand() - (double)RAND_MAX /2.0) /(double)RAND_MAX;
   }
 }
 

--- a/tf/test/transform_twist_test.cpp
+++ b/tf/test/transform_twist_test.cpp
@@ -1,6 +1,5 @@
 #include <gtest/gtest.h>
 #include <tf/transform_listener.h>
-#include <sys/time.h>
 
 #include "tf/LinearMath/Vector3.h"
 

--- a/tf/test/velocity_test.cpp
+++ b/tf/test/velocity_test.cpp
@@ -1,6 +1,5 @@
 #include <gtest/gtest.h>
 #include <tf/tf.h>
-#include <sys/time.h>
 
 #include "tf/LinearMath/Vector3.h"
 

--- a/tf_conversions/test/test_eigen_tf.cpp
+++ b/tf_conversions/test/test_eigen_tf.cpp
@@ -35,7 +35,7 @@ using namespace tf;
 
 double gen_rand(double min, double max)
 {
-  int rand_num = rand()%100+1;
+  int rand_num = std::rand()%100+1;
   double result = min + (double)((max-min)*rand_num)/101.0;
   return result;
 }

--- a/tf_conversions/test/test_kdl_tf.cpp
+++ b/tf_conversions/test/test_kdl_tf.cpp
@@ -35,7 +35,7 @@ using namespace tf;
 
 double gen_rand(double min, double max)
 {
-  int rand_num = rand()%100+1;
+  int rand_num = std::rand()%100+1;
   double result = min + (double)((max-min)*rand_num)/101.0;
   return result;
 }


### PR DESCRIPTION
This is a follow up of #182.

* Default to C++14 in `CMakeLists.txt`.
* Use `<ctime>` `<cstdlib>` for random number generation.
* Use `<cmath>` for `NAN` usage.
* Use `<chrono>` and `<thread>` for sleep.
* Conditionally undefine `NO_ERROR` to avoid symbol redefinition by `Windows` headers.