### PR TITLE
fix shebang line for python3

### DIFF
--- a/tf/CMakeLists.txt
+++ b/tf/CMakeLists.txt
@@ -148,7 +148,7 @@ install(TARGETS tf_echo tf_empty_listener tf_change_notifier tf_monitor static_t
 )
 
 # Install rosrun-able scripts
-install(PROGRAMS
+catkin_install_python(PROGRAMS
   scripts/bullet_migration_sed.py
   scripts/tf_remap
   scripts/view_frames


### PR DESCRIPTION
Similar to https://github.com/ros-visualization/rqt_graph/pull/43

Without this change the script cannot be rosrun on Noetic/Focal and results in:
`/usr/bin/env: ‘python’: No such file or directory`

Python scripts need to be installed using `catkin_install_python` for the shebang line to be rewritten to point to python3. More details at https://wiki.ros.org/UsingPython3/SourceCodeChanges#Changing_shebangs

Signed-off-by: Mikael Arguedas <mikael.arguedas@gmail.com>