### PR TITLE
Drop nonexistent rosmake doc builder.

### DIFF
--- a/tf/rosdoc.yaml
+++ b/tf/rosdoc.yaml
@@ -1,4 +1,3 @@
- - builder: rosmake
  - builder: sphinx
    name: Python API
    output_dir: python

--- a/tf_conversions/rosdoc.yaml
+++ b/tf_conversions/rosdoc.yaml
@@ -1,4 +1,3 @@
- - builder: rosmake
  - builder: sphinx
    name: Python API
    output_dir: python


### PR DESCRIPTION
This was causing some problems with stricter doc-generators like our port of catkin-tools-document to colcon.