### PR TITLE
fixed bug - quaternion_from_euler changing input in array of 1 dimension

### DIFF
--- a/tf/src/tf/transformations.py
+++ b/tf/src/tf/transformations.py
@@ -1122,7 +1122,11 @@ def quaternion_from_euler(ai, aj, ak, axes='sxyz'):
         ai, ak = ak, ai
     if parity:
         aj = -aj
-
+        
+    ai = ai.copy()
+    aj = aj.copy()
+    ak = ak.copy()
+    
     ai /= 2.0
     aj /= 2.0
     ak /= 2.0


### PR DESCRIPTION
after lots of debugging a code using the  "tf_conversions.transformations.quaternion_from_euler"
we found out that when passing an argument that is a 1-dimension array , the function changes it by half

small fix to a big nasty problem it created :)