### PR TITLE
fix: build with cxx14

### DIFF
--- a/tf/CMakeLists.txt
+++ b/tf/CMakeLists.txt
@@ -5,11 +5,11 @@ include(CheckCXXCompilerFlag)
 unset(COMPILER_SUPPORTS_CXX11 CACHE)
 if(MSVC)
   # https://docs.microsoft.com/en-us/cpp/build/reference/std-specify-language-standard-version
-  # MSVC has c++14 enabled by default, no need to specify c++11
+  # MSVC has c++14 enabled by default
 else()
-  check_cxx_compiler_flag(-std=c++11 COMPILER_SUPPORTS_CXX11)
-  if(COMPILER_SUPPORTS_CXX11)
-    add_compile_options(-std=c++11)
+  check_cxx_compiler_flag(-std=c++14 COMPILER_SUPPORTS_CXX14)
+  if(COMPILER_SUPPORTS_CXX14)
+    add_compile_options(-std=c++14)
   endif()
 endif()
 


### PR DESCRIPTION
gtest requires c++ 14, boost also warns about c++ 11 being deprecated nowadays