### PR TITLE
Removes extra semicolon for function definitions

### DIFF
--- a/kdl_conversions/src/kdl_msg.cpp
+++ b/kdl_conversions/src/kdl_msg.cpp
@@ -155,10 +155,10 @@ void PoseMsgToKDL(const geometry_msgs::Pose &m, KDL::Frame &k) { poseMsgToKDL(m,
 void PoseKDLToMsg(const KDL::Frame &k, geometry_msgs::Pose &m) { poseKDLToMsg(k, m);}
 
 /// Converts a Twist message into a KDL Twist
-void TwistMsgToKDL(const geometry_msgs::Twist &m, KDL::Twist &k) {twistMsgToKDL(m, k);};
+void TwistMsgToKDL(const geometry_msgs::Twist &m, KDL::Twist &k) {twistMsgToKDL(m, k);}
 
 /// Converts a KDL Twist into a Twist message
-void TwistKDLToMsg(const KDL::Twist &k, geometry_msgs::Twist &m){twistKDLToMsg(k, m);};
+void TwistKDLToMsg(const KDL::Twist &k, geometry_msgs::Twist &m){twistKDLToMsg(k, m);}
 
 
 }  // namespace tf

--- a/tf/include/tf/LinearMath/QuadWord.h
+++ b/tf/include/tf/LinearMath/QuadWord.h
@@ -63,13 +63,13 @@ protected:
   /**@brief Return the z value */
 		TFSIMD_FORCE_INLINE const tfScalar& getZ() const { return m_floats[2]; }
   /**@brief Set the x value */
-		TFSIMD_FORCE_INLINE void	setX(tfScalar x) { m_floats[0] = x;};
+		TFSIMD_FORCE_INLINE void	setX(tfScalar x) { m_floats[0] = x;}
   /**@brief Set the y value */
-		TFSIMD_FORCE_INLINE void	setY(tfScalar y) { m_floats[1] = y;};
+		TFSIMD_FORCE_INLINE void	setY(tfScalar y) { m_floats[1] = y;}
   /**@brief Set the z value */
-		TFSIMD_FORCE_INLINE void	setZ(tfScalar z) { m_floats[2] = z;};
+		TFSIMD_FORCE_INLINE void	setZ(tfScalar z) { m_floats[2] = z;}
   /**@brief Set the w value */
-		TFSIMD_FORCE_INLINE void	setW(tfScalar w) { m_floats[3] = w;};
+		TFSIMD_FORCE_INLINE void	setW(tfScalar w) { m_floats[3] = w;}
   /**@brief Return the x value */
 		TFSIMD_FORCE_INLINE const tfScalar& x() const { return m_floats[0]; }
   /**@brief Return the y value */

--- a/tf/include/tf/LinearMath/Vector3.h
+++ b/tf/include/tf/LinearMath/Vector3.h
@@ -252,13 +252,13 @@ public:
   /**@brief Return the z value */
 		TFSIMD_FORCE_INLINE const tfScalar& getZ() const { return m_floats[2]; }
   /**@brief Set the x value */
-		TFSIMD_FORCE_INLINE void	setX(tfScalar x) { m_floats[0] = x;};
+		TFSIMD_FORCE_INLINE void	setX(tfScalar x) { m_floats[0] = x;}
   /**@brief Set the y value */
-		TFSIMD_FORCE_INLINE void	setY(tfScalar y) { m_floats[1] = y;};
+		TFSIMD_FORCE_INLINE void	setY(tfScalar y) { m_floats[1] = y;}
   /**@brief Set the z value */
-		TFSIMD_FORCE_INLINE void	setZ(tfScalar z) {m_floats[2] = z;};
+		TFSIMD_FORCE_INLINE void	setZ(tfScalar z) {m_floats[2] = z;}
   /**@brief Set the w value */
-		TFSIMD_FORCE_INLINE void	setW(tfScalar w) { m_floats[3] = w;};
+		TFSIMD_FORCE_INLINE void	setW(tfScalar w) { m_floats[3] = w;}
   /**@brief Return the x value */
 		TFSIMD_FORCE_INLINE const tfScalar& x() const { return m_floats[0]; }
   /**@brief Return the y value */

--- a/tf/include/tf/tf.h
+++ b/tf/include/tf/tf.h
@@ -343,15 +343,15 @@ public:
   /** 
    * \brief Get the tf_prefix this is running with
    */
-  std::string getTFPrefix() const { return tf_prefix_;};
+  std::string getTFPrefix() const { return tf_prefix_;}
 
   //Declare that it is safe to call waitForTransform
-  void setUsingDedicatedThread(bool value) { tf2_buffer_ptr_->setUsingDedicatedThread(value);};
+  void setUsingDedicatedThread(bool value) { tf2_buffer_ptr_->setUsingDedicatedThread(value);}
   // Get the state of using_dedicated_thread_ from the buffer
-  bool isUsingDedicatedThread() { return tf2_buffer_ptr_->isUsingDedicatedThread();};
+  bool isUsingDedicatedThread() { return tf2_buffer_ptr_->isUsingDedicatedThread();}
 
   // Get a copy of the shared_ptr containing the tf2_ros::Buffer object
-  std::shared_ptr<tf2_ros::Buffer> getTF2BufferPtr() { return tf2_buffer_ptr_;};
+  std::shared_ptr<tf2_ros::Buffer> getTF2BufferPtr() { return tf2_buffer_ptr_;}
 
 protected:
 

--- a/tf/include/tf/transform_datatypes.h
+++ b/tf/include/tf/transform_datatypes.h
@@ -67,7 +67,7 @@ class Stamped : public T{
     T (input), stamp_ ( timestamp ), frame_id_ (frame_id){ } ;
   
   /** Set the data element */
-  void setData(const T& input){*static_cast<T*>(this) = input;};
+  void setData(const T& input){*static_cast<T*>(this) = input;}
 };
 
 /** \brief Comparison Operator for Stamped datatypes */
@@ -91,7 +91,7 @@ public:
   StampedTransform() { };
 
   /** \brief Set the inherited Transform data */
-  void setData(const tf::Transform& input){*static_cast<tf::Transform*>(this) = input;};
+  void setData(const tf::Transform& input){*static_cast<tf::Transform*>(this) = input;}
 
 };
 

--- a/tf_conversions/include/tf_conversions/tf_kdl.h
+++ b/tf_conversions/include/tf_conversions/tf_kdl.h
@@ -73,35 +73,35 @@ ROS_DEPRECATED geometry_msgs::Pose addDelta(const geometry_msgs::Pose &pose, con
 
 /// Converts a tf Pose into a KDL Frame
 ROS_DEPRECATED void PoseTFToKDL(const tf::Pose &t, KDL::Frame &k);
-void inline PoseTFToKDL(const tf::Pose &t, KDL::Frame &k) {poseTFToKDL(t, k);};
+void inline PoseTFToKDL(const tf::Pose &t, KDL::Frame &k) {poseTFToKDL(t, k);}
 
 /// Converts a KDL Frame into a tf Pose
 ROS_DEPRECATED void PoseKDLToTF(const KDL::Frame &k, tf::Pose &t);
-void inline PoseKDLToTF(const KDL::Frame &k, tf::Pose &t) {poseKDLToTF(k, t);};
+void inline PoseKDLToTF(const KDL::Frame &k, tf::Pose &t) {poseKDLToTF(k, t);}
 
 /// Converts a tf Quaternion into a KDL Rotation
 ROS_DEPRECATED void QuaternionTFToKDL(const tf::Quaternion &t, KDL::Rotation &k);
-void inline QuaternionTFToKDL(const tf::Quaternion &t, KDL::Rotation &k) {quaternionTFToKDL(t, k);};
+void inline QuaternionTFToKDL(const tf::Quaternion &t, KDL::Rotation &k) {quaternionTFToKDL(t, k);}
 
 /// Converts a tf Quaternion into a KDL Rotation
 ROS_DEPRECATED void QuaternionKDLToTF(const KDL::Rotation &k, tf::Quaternion &t);
-void inline QuaternionKDLToTF(const KDL::Rotation &k, tf::Quaternion &t) {quaternionKDLToTF(k, t);};
+void inline QuaternionKDLToTF(const KDL::Rotation &k, tf::Quaternion &t) {quaternionKDLToTF(k, t);}
 
 /// Converts a tf Transform into a KDL Frame
 ROS_DEPRECATED void TransformTFToKDL(const tf::Transform &t, KDL::Frame &k);
-void inline TransformTFToKDL(const tf::Transform &t, KDL::Frame &k) {transformTFToKDL(t, k);};
+void inline TransformTFToKDL(const tf::Transform &t, KDL::Frame &k) {transformTFToKDL(t, k);}
 
 /// Converts a KDL Frame into a tf Transform
 ROS_DEPRECATED void TransformKDLToTF(const KDL::Frame &k, tf::Transform &t);
-void inline TransformKDLToTF(const KDL::Frame &k, tf::Transform &t)  {transformKDLToTF(k, t);};
+void inline TransformKDLToTF(const KDL::Frame &k, tf::Transform &t)  {transformKDLToTF(k, t);}
 
 /// Converts a tf Vector3 into a KDL Vector
 ROS_DEPRECATED void VectorTFToKDL(const tf::Vector3 &t, KDL::Vector &k);
-void inline VectorTFToKDL(const tf::Vector3 &t, KDL::Vector &k) {vectorTFToKDL(t, k);};
+void inline VectorTFToKDL(const tf::Vector3 &t, KDL::Vector &k) {vectorTFToKDL(t, k);}
 
 /// Converts a tf Vector3 into a KDL Vector
 ROS_DEPRECATED void VectorKDLToTF(const KDL::Vector &k, tf::Vector3 &t);
-void inline VectorKDLToTF(const KDL::Vector &k, tf::Vector3 &t) {vectorKDLToTF(k, t);};
+void inline VectorKDLToTF(const KDL::Vector &k, tf::Vector3 &t) {vectorKDLToTF(k, t);}
 
 
 } // namespace tf


### PR DESCRIPTION
Removes extra semicolon. This gets picked up as a warning if any downstream libraries are compiling with ``-Wpedantic``, and include header files :

```sh
/opt/ros/noetic/include/tf_conversions/tf_kdl.h:76:79: warning: extra ‘;’ [-Wpedantic]
   76 | void inline PoseTFToKDL(const tf::Pose &t, KDL::Frame &k) {poseTFToKDL(t, k);};
```