### PR TITLE
Deprecating tf2 C Headers

### DIFF
--- a/tf/include/tf/exceptions.h
+++ b/tf/include/tf/exceptions.h
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2008, Willow Garage, Inc.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  *     * Redistributions of source code must retain the above copyright
  *       notice, this list of conditions and the following disclaimer.
  *     * Redistributions in binary form must reproduce the above copyright
@@ -13,7 +13,7 @@
  *     * Neither the name of the Willow Garage, Inc. nor the names of its
  *       contributors may be used to endorse or promote products derived from
  *       this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -33,7 +33,7 @@
 #define TF_EXCEPTIONS_H
 
 #include <stdexcept>
-#include <tf2/exceptions.h>
+#include <tf2/exceptions.hpp>
 
 namespace tf{
 
@@ -42,7 +42,7 @@ typedef tf2::TransformException TransformException;
 typedef tf2::LookupException LookupException;
 typedef tf2::ConnectivityException ConnectivityException;
 typedef tf2::ExtrapolationException ExtrapolationException;
-typedef tf2::InvalidArgumentException InvalidArgument; 
+typedef tf2::InvalidArgumentException InvalidArgument;
 
 
 }


### PR DESCRIPTION
Related to this [pull request](https://github.com/ros2/geometry2/pull/720) in `geometry2` in which we deprecated the `.h` style headers in favor of `.hpp`.

Edit: I should mention this is meant to be a preemptive PR for if/when the related pull request gets approved. I'm also working on a backport so there won't be distribution issues